### PR TITLE
Run Lint workflow on pushes to main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,9 @@
 name: 'Lint'
 on:
   pull_request:
+  push:
+    branches:    
+      - main
   workflow_dispatch:
 jobs:
   lint:


### PR DESCRIPTION
Additionally configuring the linting workflow here to run on pushes to the main branch, reference https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#push