### PR TITLE
Fix W&B Environment variable name

### DIFF
--- a/cosmos1/models/autoregressive/nemo/post_training/README.md
+++ b/cosmos1/models/autoregressive/nemo/post_training/README.md
@@ -147,7 +147,7 @@ Complete the following steps to post-train the Cosmos-1.0-Autoregressive-4B mode
 
    # Optionally, you can monitor training progress with Weights and Biases (wandb).
    export WANDB_API_KEY="</your/wandb/api/key>"
-   export WANDB_PROJECT_NAME="cosmos-autoregressive-nemo-finetuning"
+   export WANDB_PROJECT="cosmos-autoregressive-nemo-finetuning"
    export WANDB_RUN_ID="cosmos_autoregressive_4b_finetune"
    ```
 2. Run the following command for Cosmos-1.0-Autoregressive-4B post-training:

--- a/cosmos1/models/diffusion/nemo/post_training/README.md
+++ b/cosmos1/models/diffusion/nemo/post_training/README.md
@@ -150,7 +150,7 @@ Complete the following steps to post-train the Cosmos-1.0-Diffusion-7B-Text2Worl
 
    # Optionally, you can monitor training progress with Weights and Biases (wandb).
    export WANDB_API_KEY="</your/wandb/api/key>"
-   export WANDB_PROJECT_NAME="cosmos-diffusion-nemo-post-training"
+   export WANDB_PROJECT="cosmos-diffusion-nemo-post-training"
    export WANDB_RUN_ID="cosmos_diffusion_7b_text2world_finetune"
    ```
 2. Run the following command for Cosmos-Diffusion-Text2World-7B general post-training:


### PR DESCRIPTION
Fix [W&B Environment](https://docs.wandb.ai/guides/track/environment-variables/#optional-environment-variables) variable at post-training README.
WANDB_PROJECT_NAME → WANDB_PROJECT to set W&B projet name correctly.
