### PR TITLE
Sync cookbook README defaults with notebook source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A `text-to-video` run takes a while: the first run downloads `Cosmos3-Nano`, and
 ```python
 import torch
 from diffusers import Cosmos3OmniPipeline
+from diffusers.schedulers.scheduling_unipc_multistep import UniPCMultistepScheduler
 from diffusers.utils import export_to_video
 
 pipe = Cosmos3OmniPipeline.from_pretrained(
@@ -240,13 +241,22 @@ pipe = Cosmos3OmniPipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
     device_map="cuda",
 )
+pipe.scheduler = UniPCMultistepScheduler.from_config(pipe.scheduler.config, flow_shift=10.0)
 
 result = pipe(
     prompt="A mobile robot navigates a warehouse aisle and stops at a shelf.",
+    negative_prompt="",
+    image=None,
     num_frames=189,
     height=720,
     width=1280,
-    fps=24.0,
+    fps=24,
+    num_inference_steps=35,
+    guidance_scale=6.0,
+    enable_sound=False,
+    add_resolution_template=False,
+    add_duration_template=False,
+    generator=torch.Generator(device="cuda").manual_seed(1234),
 )
 
 export_to_video(result.video, "cosmos3_t2v.mp4", fps=24, macro_block_size=1)
@@ -287,12 +297,16 @@ docker run --runtime nvidia --gpus all \
   --omni \
   --model-class-name Cosmos3OmniDiffusersPipeline \
   --allowed-local-media-path / \
-  --port 8000
+  --port 8000 \
+  --init-timeout 1800
 ```
+
+Cosmos3 checkpoints can exceed the default server init timeout; use
+`--init-timeout 1800` on every `vllm serve` command in this section.
 
 vLLM-Omni prints `Application startup complete.` when the API is ready.
 
-For `nvidia/Cosmos3-Super` (the larger 64B model), split weights across GPUs and optionally offload layers to reduce peak memory: `--tensor-parallel-size` splits model weights across multiple GPUs, and `--enable-layerwise-offload` offloads transformer blocks between CPU and GPU with a latency tradeoff and extra CPU RAM use. For example, on four GPUs, add `--tensor-parallel-size 4 --enable-layerwise-offload` to the `vllm serve` command.
+For `nvidia/Cosmos3-Super` (the larger 64B model), split weights across GPUs and optionally offload layers to reduce peak memory: `--tensor-parallel-size` splits model weights across multiple GPUs, and `--enable-layerwise-offload` offloads transformer blocks between CPU and GPU with a latency tradeoff and extra CPU RAM use. For example, on four GPUs, add `--tensor-parallel-size 4 --enable-layerwise-offload --init-timeout 1800` to the `vllm serve` command.
 
 Additional parallelism options:
 
@@ -316,7 +330,7 @@ uv pip install --torch-backend=cu130 \
 #   "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@refs/pull/3454/head"
 ```
 
-Then run `vllm serve nvidia/Cosmos3-Nano --omni --model-class-name Cosmos3OmniDiffusersPipeline --allowed-local-media-path / --port 8000` directly, without the `docker run ... vllm/vllm-omni:cosmos3` wrapper.
+Then run `vllm serve nvidia/Cosmos3-Nano --omni --model-class-name Cosmos3OmniDiffusersPipeline --allowed-local-media-path / --port 8000 --init-timeout 1800` directly, without the `docker run ... vllm/vllm-omni:cosmos3` wrapper.
 
 Vision endpoints:
 
@@ -345,11 +359,13 @@ curl -sS -X POST http://localhost:8000/v1/videos/sync \
   --form-string "prompt=A small warehouse robot moves a blue box across a clean floor." \
   --form-string "negative_prompt=blurry, distorted, low quality" \
   --form-string "size=1280x720" \
-  --form-string "num_frames=81" \
+  --form-string "num_frames=189" \
   --form-string "fps=24" \
   --form-string "num_inference_steps=35" \
-  --form-string "guidance_scale=4.0" \
-  --form-string "seed=42" \
+  --form-string "guidance_scale=6.0" \
+  --form-string "flow_shift=10.0" \
+  --form-string "seed=0" \
+  --form-string 'extra_params={"use_resolution_template":false,"use_duration_template":false,"guardrails":true}' \
   -o cosmos3_t2v_output.mp4
 ```
 
@@ -401,7 +417,8 @@ stages:
 vllm serve nvidia/Cosmos3-Nano --omni \
   --model-class-name Cosmos3OmniDiffusersPipeline \
   --deploy-config no_guardrails.yaml \
-  --port 8000
+  --port 8000 \
+  --init-timeout 1800
 ```
 
 References:
@@ -436,6 +453,10 @@ vllm serve nvidia/Cosmos3-Nano \
   --allowed-local-media-path / \
   --port 8000
 ```
+
+For notebook launch commands (Cosmos3-Super on four GPUs, media-path defaults, and
+full flag sets), see
+[cookbooks/cosmos3/README.md — Start the server](cookbooks/cosmos3/README.md#start-the-server).
 
 If your vLLM build reports that DeepGEMM is unavailable, disable it before starting the server:
 

--- a/cookbooks/cosmos3/README.md
+++ b/cookbooks/cosmos3/README.md
@@ -139,55 +139,169 @@ export VLLM_USE_DEEP_GEMM=0
 > `.venv/bin` is on `PATH` (e.g. `source .venv/bin/activate`). FlashInfer's
 > just-in-time kernel build shells out to `ninja`, which lives in the venv.
 
+### Start the server
+
+All Reasoner cookbooks talk to an OpenAI-compatible chat-completions API. After
+[installing vLLM](#vllm), run the commands below from
+`cookbooks/cosmos3/reasoner` (same working directory as
+[`run_with_vllm.ipynb`](reasoner/run_with_vllm.ipynb)). That sets
+`$(dirname "$(pwd)")` to `<cosmos>/cookbooks/cosmos3`, which matches the
+notebook's `COSMOS3_MEDIA_ROOT`.
+
+**Cosmos3-Nano** (single GPU, port 8000):
+
+```bash
+CUDA_VISIBLE_DEVICES=0 \
+vllm serve nvidia/Cosmos3-Nano \
+  --hf-overrides '{"architectures": ["Cosmos3ReasonerForConditionalGeneration"]}' \
+  --tensor-parallel-size 1 \
+  --mm-encoder-tp-mode data \
+  --async-scheduling \
+  --allowed-local-media-path "$(dirname "$(pwd)")" \
+  --media-io-kwargs '{"video": {"num_frames": -1}}' \
+  --port 8000
+```
+
+**Cosmos3-Super** (four GPUs; default in [`run_with_vllm.ipynb`](reasoner/run_with_vllm.ipynb), port 8001):
+
+```bash
+export COSMOS3_MEDIA_ROOT="$(dirname "$(pwd)")"
+export VLLM_PORT="${VLLM_PORT:-8001}"
+
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
+vllm serve nvidia/Cosmos3-Super \
+  --hf-overrides '{"architectures": ["Cosmos3ReasonerForConditionalGeneration"]}' \
+  --tensor-parallel-size 4 \
+  --mm-encoder-tp-mode data \
+  --async-scheduling \
+  --allowed-local-media-path "$COSMOS3_MEDIA_ROOT" \
+  --media-io-kwargs '{"video": {"num_frames": -1}}' \
+  --port "$VLLM_PORT"
+```
+
+The Super notebook polls `/health` for up to 1800 seconds on first start while CUDA
+graphs compile.
+
+| Option | Use |
+| --- | --- |
+| `--tensor-parallel-size` | Number of GPUs for tensor-parallel inference |
+| `--mm-encoder-tp-mode data` | Data parallelism for the visual encoder |
+| `--media-io-kwargs '{"video": {"num_frames": -1}}'` | Lets the processor see all frames before downstream sampling |
+| `--allowed-local-media-path` | Must cover local `file://` media paths; defaults to `<cosmos>/cookbooks/cosmos3` when run from `cookbooks/cosmos3/reasoner` |
+
 ## vLLM-Omni
 
 OpenAI-compatible **generation** server (image/video/audio/action) for the
-Generator cookbooks. The simplest path is the prebuilt Docker image
-`vllm/vllm-omni:cosmos3`:
+Generator cookbooks.
+
+Cosmos3 checkpoints can exceed the default server init timeout — always pass
+`--init-timeout 1800` on every `vllm serve` command below.
+
+### Option 1: Docker (recommended)
+
+The prebuilt image `vllm/vllm-omni:cosmos3` supports every Generator modality
+(including action). Pull once:
 
 ```bash
 docker pull vllm/vllm-omni:cosmos3
 ```
 
-Start a Nano server (publishes the OpenAI-compatible API on port 8000; mount any
-directory whose local media/action files the server should read):
+Set paths once; adjust for your checkout and cache location:
 
 ```bash
-docker run --runtime nvidia --gpus all \
-  -v ~/.cache/huggingface:/root/.cache/huggingface \
-  -v "$(pwd):/workspace" \
-  -p 8000:8000 \
-  --ipc=host \
+export HF_HOME="${HF_HOME:-$HOME/.cache/huggingface}"
+export COSMOS3_WORKDIR="${COSMOS3_WORKDIR:-$(pwd)}"
+export COSMOS3_HOST_PORT="${COSMOS3_HOST_PORT:-8000}"
+```
+
+The container listens on port 8000; `-p "${COSMOS3_HOST_PORT}:8000"` publishes it
+on the host. Generator notebooks often use `COSMOS3_HOST_PORT=8001` so port 8000
+stays free for a Reasoner server.
+
+**Cosmos3-Nano** (single GPU):
+
+```bash
+docker run --runtime nvidia --gpus '"device=0"' \
+  -e CUDA_DEVICE_ORDER=PCI_BUS_ID \
+  -v "${HF_HOME}:/root/.cache/huggingface" \
+  -v "${COSMOS3_WORKDIR}:/workspace" \
+  -p "${COSMOS3_HOST_PORT}:8000" --ipc=host \
   vllm/vllm-omni:cosmos3 \
   vllm serve nvidia/Cosmos3-Nano \
-  --omni \
-  --model-class-name Cosmos3OmniDiffusersPipeline \
-  --allowed-local-media-path / \
-  --port 8000
+    --omni \
+    --model-class-name Cosmos3OmniDiffusersPipeline \
+    --allowed-local-media-path / \
+    --port 8000 \
+    --init-timeout 1800
 ```
 
-For **Cosmos3-Super** (the larger 64B model), split the weights across GPUs and,
-if needed, offload layers to reduce peak memory:
+**Cosmos3-Super** (all GPUs; add tensor parallelism and layerwise offload):
 
 ```bash
 docker run --runtime nvidia --gpus all \
-  -v ~/.cache/huggingface:/root/.cache/huggingface \
-  -v "$(pwd):/workspace" \
-  -p 8000:8000 \
-  --ipc=host \
+  -v "${HF_HOME}:/root/.cache/huggingface" \
+  -v "${COSMOS3_WORKDIR}:/workspace" \
+  -p "${COSMOS3_HOST_PORT}:8000" --ipc=host \
   vllm/vllm-omni:cosmos3 \
   vllm serve nvidia/Cosmos3-Super \
+    --omni \
+    --model-class-name Cosmos3OmniDiffusersPipeline \
+    --allowed-local-media-path / \
+    --tensor-parallel-size 4 \
+    --enable-layerwise-offload \
+    --port 8000 \
+    --init-timeout 1800
+```
+
+Mount any directory that holds local media or action JSON files referenced in
+requests. Set `--allowed-local-media-path /` (as above) when the whole container
+filesystem should be readable.
+
+vLLM-Omni prints `Application startup complete.` when the API is ready.
+
+### Option 2: Native venv (limited modalities)
+
+To install from the upstreaming PR branch instead of Docker (text-to-image,
+text-to-video, and image-to-video only — not action or sound yet), create a venv
+and pick the CUDA build that matches your driver (see
+[CUDA driver and the `cuXXX` backend](#cuda-driver-and-the-cuxxx-backend)):
+
+```bash
+uv venv --python 3.13 --seed --managed-python
+source .venv/bin/activate
+
+# CUDA 13 driver:
+uv pip install --torch-backend=cu130 \
+  "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@refs/pull/3454/head"
+
+# CUDA 12.x driver:
+# uv pip install --torch-backend=cu128 \
+#   "vllm-omni @ git+https://github.com/vllm-project/vllm-omni.git@refs/pull/3454/head"
+```
+
+Run the same `vllm serve` arguments as in the Docker commands above, directly on
+the host (no `docker run` wrapper):
+
+```bash
+vllm serve nvidia/Cosmos3-Nano \
   --omni \
   --model-class-name Cosmos3OmniDiffusersPipeline \
   --allowed-local-media-path / \
-  --tensor-parallel-size 4 \
-  --enable-layerwise-offload \
-  --port 8000
+  --port 8000 \
+  --init-timeout 1800
 ```
 
-If you installed vLLM-Omni from the PR branch instead, run the same
-`vllm serve ... --omni ...` command directly, without the
-`docker run ... vllm/vllm-omni:cosmos3` wrapper.
+For Super, add `--tensor-parallel-size 4 --enable-layerwise-offload`.
+
+Additional parallelism options (Docker or native):
+
+| Option | Use |
+| --- | --- |
+| `--cfg-parallel-size 2` | Runs positive and negative CFG branches on two GPUs |
+| `--ulysses-degree 2` | Ulysses sequence parallelism across GPUs |
+
+Ensure the server has enough GPUs for the product of enabled degrees
+(`tensor_parallel_size` × `cfg_parallel_size` × `ulysses_degree`).
 
 ## Verify the environment
 
@@ -206,7 +320,8 @@ if torch.cuda.is_available():
 PY
 ```
 
-For a vLLM / vLLM-Omni server, confirm it is serving the model:
+For a vLLM / vLLM-Omni server, confirm it is serving the model (use the host port
+you set with `COSMOS3_HOST_PORT` or `VLLM_PORT`):
 
 ```bash
 curl http://localhost:8000/v1/models

--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -40,11 +40,11 @@ dynamics on Nano looks like:
 ```bash
 torchrun --nproc-per-node=1 \
   -m cosmos_framework.scripts.inference \
-  --parallelism-preset=throughput \
+  --parallelism-preset=latency \
   -i <forward-dynamics input spec>.json \
   -o /tmp/cosmos3_action_fd \
   --checkpoint-path Cosmos3-Nano \
-  --seed=0
+  --seed 0
 ```
 
 The input spec pairs a start image with an action trajectory. The notebooks
@@ -66,35 +66,30 @@ visualize the generated videos:
 
 ### Quickstart
 
-Set up the environment: [vLLM-Omni setup](../../README.md#vllm-omni).
-Start the server from this folder. The container listens on port 8000; the
-example publishes it to host port 8001:
+Set up the environment and start the server:
+[vLLM-Omni setup](../../README.md#vllm-omni) (Docker recommended). From the
+`cosmos` repo root, set `export COSMOS3_WORKDIR=$PWD` and
+`export COSMOS3_HOST_PORT=8001`, then run the Docker command from the env setup
+guide. Wait until this succeeds:
 
 ```bash
-docker rm -f cosmos3-vllm-omni-notebook 2>/dev/null || true
-
-docker run -d --name cosmos3-vllm-omni-notebook \
-  --runtime nvidia --gpus '"device=0"' \
-  -e CUDA_DEVICE_ORDER=PCI_BUS_ID \
-  -v ~/.cache/huggingface:/root/.cache/huggingface \
-  -v "$PWD:/workspace" \
-  -p 8001:8000 --ipc=host \
-  vllm/vllm-omni:cosmos3 \
-  vllm serve nvidia/Cosmos3-Nano \
-    --omni \
-    --model-class-name Cosmos3OmniDiffusersPipeline \
-    --allowed-local-media-path / \
-    --port 8000
-
-# Wait until this returns model metadata before sending requests:
 curl http://localhost:8001/v1/models
 ```
 
 Forward-dynamics requests are multipart `POST`s to `/v1/videos` — a start image
 under `files={"input_reference": ...}` plus an `extra_params` payload carrying the
-action trajectory. The vLLM notebook builds the full request body for AV,
-DROID, and UMI examples, including autoregressive chunked generation for the
-robotics examples.
+action trajectory. The vLLM notebooks use these diffusion defaults for action
+generation (see [`run_fd_with_vllm.ipynb`](./run_fd_with_vllm.ipynb) and
+[`run_id_with_vllm.ipynb`](./run_id_with_vllm.ipynb)):
+
+| Field | Value |
+| --- | --- |
+| `num_inference_steps` | `30` |
+| `guidance_scale` | `1.0` |
+| `flow_shift` | `10.0` |
+
+The notebooks build the full request body for AV, DROID, and UMI examples,
+including autoregressive chunked generation for the robotics examples.
 
 ### Notebook walkthrough
 

--- a/cookbooks/cosmos3/generator/audiovisual/README.md
+++ b/cookbooks/cosmos3/generator/audiovisual/README.md
@@ -15,14 +15,47 @@ to get one generation running per backend — run them from this folder.
 
 Set up the environment: [Cosmos Framework setup](../../README.md#cosmos-framework).
 Activate the framework venv created during setup (`packages/cosmos3/.venv` at the
-repo root), or call its `torchrun` by path, then launch a text-to-video generation
+repo root), or call its `torchrun` by path. The notebook builds a full inference
+payload JSON (not the raw prompt asset alone); build one the same way, then run
 from this folder:
 
 ```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+prompt = json.dumps(
+    json.load(open("assets/prompts/text2video/robot_kitchen.json")),
+    ensure_ascii=True,
+    separators=(",", ":"),
+)
+negative = json.dumps(
+    json.load(open("assets/negative_prompts/text2video/neg_prompt.json")),
+    ensure_ascii=True,
+    separators=(",", ":"),
+)
+payload = {
+    "model_mode": "text2video",
+    "name": "robot_kitchen",
+    "prompt": prompt,
+    "negative_prompt": negative,
+    "enable_sound": False,
+    "num_steps": 35,
+    "guidance": 6.0,
+    "shift": 10.0,
+    "fps": 24,
+    "num_frames": 189,
+    "resolution": "720",
+    "aspect_ratio": "16,9",
+    "seed": 0,
+}
+Path("/tmp/cosmos3_t2v_payload.json").write_text(json.dumps(payload, indent=2) + "\n")
+PY
+
 torchrun --nproc-per-node=1 \
   -m cosmos_framework.scripts.inference \
   --parallelism-preset=throughput \
-  -i assets/prompts/text2video/robot_kitchen.json \
+  -i /tmp/cosmos3_t2v_payload.json \
   -o /tmp/cosmos3_t2v_framework \
   --checkpoint-path Cosmos3-Nano \
   --seed=0
@@ -92,9 +125,11 @@ audio) using `Cosmos3OmniPipeline`, including how to preview the generated media
 
 ### Quickstart
 
-Set up the environment and start a Nano server:
-[vLLM-Omni setup](../../README.md#vllm-omni) — the `docker run` command there
-serves the OpenAI-compatible API on port 8000.
+Set up the environment and start the server:
+[vLLM-Omni setup](../../README.md#vllm-omni) (Docker recommended). Run the
+Docker command from this folder (`COSMOS3_WORKDIR` defaults to the current
+directory) with **`COSMOS3_HOST_PORT=8000`** unless you already have another
+server on that port.
 
 Send a text-to-video request with the OpenAI-compatible video API:
 
@@ -139,7 +174,7 @@ For image-to-video, post to the same endpoint with an image under
 ### Notebook walkthrough
 
 [`run_with_vllm_omni.ipynb`](./run_with_vllm_omni.ipynb) is the full tutorial for
-the vLLM-Omni backend: it documents the Docker and PR-branch server options (Nano
-and Super, with tensor parallelism, layerwise offload, and CFG-parallel variants)
-and walks through text-to-image, text-to-video, and image-to-video requests with
-audio on or off.
+the vLLM-Omni backend: it walks through text-to-image, text-to-video, and
+image-to-video requests with audio on or off. Server launch options (Nano and
+Super, tensor parallelism, layerwise offload, and CFG-parallel variants) live in
+the [shared environment setup guide](../../README.md#vllm-omni).

--- a/cookbooks/cosmos3/reasoner/README.md
+++ b/cookbooks/cosmos3/reasoner/README.md
@@ -64,23 +64,16 @@ because the current Cosmos Framework Reasoner path expects image inputs through
 
 ### Quickstart
 
-Set up the environment: [vLLM setup](../README.md#vllm).
+Set up the environment and start the server:
+[vLLM setup](../README.md#vllm) (install) and
+[Start the server](../README.md#start-the-server) (launch commands).
 
-Start an OpenAI-compatible Nano server on a single GPU:
+The quickstart below uses **Cosmos3-Nano** on port 8000. The
+[`run_with_vllm.ipynb`](./run_with_vllm.ipynb) notebook defaults to
+**Cosmos3-Super** on port **8001** — use that launch command from the env setup
+guide and point the client at `http://localhost:8001/v1`.
 
-```bash
-CUDA_VISIBLE_DEVICES=0 \
-vllm serve nvidia/Cosmos3-Nano \
-    --hf-overrides '{"architectures": ["Cosmos3ReasonerForConditionalGeneration"]}' \
-    --tensor-parallel-size 1 \
-    --mm-encoder-tp-mode data \
-    --async-scheduling \
-    --allowed-local-media-path "$(dirname "$(pwd)")" \
-    --media-io-kwargs '{"video": {"num_frames": -1}}' \
-    --port 8000
-```
-
-Once it is up, query it with the OpenAI client:
+Once the server is ready, query it with the OpenAI client:
 
 ```python
 import openai
@@ -112,13 +105,14 @@ print(response.choices[0].message.content)
 
 ### Notebook walkthrough
 
-[`run_with_vllm.ipynb`](./run_with_vllm.ipynb) ships configured for
-**`Cosmos3-Super`** (served across 4 GPUs) and walks through many more image and
-video examples: detailed captioning, VQA, temporal localization, embodied
-reasoning, common-sense reasoning, 2D grounding, describe-anything, action CoT
-trajectories, driving scenes, physical-plausibility, and situation understanding.
-To run a different model, only the **server launch cell** and the **client port**
-change; every example resolves the model dynamically
+[`run_with_vllm.ipynb`](./run_with_vllm.ipynb) uses the **Cosmos3-Super** launch
+from the [environment setup guide](../README.md#start-the-server) and walks
+through many more image and video examples: detailed captioning,
+VQA, temporal localization, embodied reasoning, common-sense reasoning, 2D
+grounding, describe-anything, action CoT trajectories, driving scenes,
+physical-plausibility, and situation understanding. To run a different model,
+change only the **server launch** command and the client `base_url`; every
+example resolves the model dynamically
 (`MODEL = client.models.list().data[0].id`), so the prompts work unchanged.
 
 ## Run with Transformers


### PR DESCRIPTION
## Summary
- Align cookbook README quickstarts with notebook defaults for Diffusers, vLLM-Omni, Cosmos Framework, and Reasoner vLLM serving.
- Add `--init-timeout 1800` to vLLM-Omni server examples, update generator request params (steps, guidance, flow_shift, seeds, extra_params), and document action-specific diffusion defaults.
- Fix Cosmos Framework audiovisual quickstart to build full inference payload JSON (matching notebook `FIXED_SAMPLING`) and add Reasoner Nano/Super server launch docs.

## Test plan
- [x] Cross-checked all 9 cookbooks against their README quickstarts (automated audit passed)
- [ ] Review rendered README markdown on GitHub
- [ ] Spot-check one generator and one reasoner quickstart command against the corresponding notebook