### PR TITLE
Set vLLM action output size from input frames

### DIFF
--- a/cookbooks/cosmos3/generator/action/run_fd_with_vllm.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_fd_with_vllm.ipynb
@@ -316,7 +316,7 @@
     "<output>/action_forward_dynamics_av_custom/<name>/vision.mp4\n",
     "```\n",
     "\n",
-    "The request intentionally omits `size`, `width`, and `height`; Cosmos3/vLLM chooses the action canvas from `image_size=480` and preserves aspect ratio by padding.\n"
+    "The request sets top-level `size` to the conditioning image resolution so vLLM-Omni returns output at the input resolution without reflection padding.\n"
    ]
   },
   {
@@ -330,6 +330,8 @@
     "import mimetypes\n",
     "import time\n",
     "from pathlib import Path\n",
+    "\n",
+    "from PIL import Image\n",
     "\n",
     "try:\n",
     "    import requests\n",
@@ -361,6 +363,7 @@
     "    run_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "    vision_path = Path(record[\"vision_path\"])\n",
+    "    input_width, input_height = Image.open(vision_path).size\n",
     "    mime_type = mimetypes.guess_type(vision_path.name)[0] or \"application/octet-stream\"\n",
     "    extra_params = {\n",
     "        \"action_mode\": \"forward_dynamics\",\n",
@@ -376,6 +379,7 @@
     "        \"prompt\": prompt,\n",
     "        \"num_frames\": record[\"action_chunk_size\"] + 1,\n",
     "        \"fps\": record[\"fps\"],\n",
+    "        \"size\": f\"{input_width}x{input_height}\",\n",
     "        \"num_inference_steps\": 30,\n",
     "        \"guidance_scale\": 1.0,\n",
     "        \"flow_shift\": 10.0,\n",
@@ -589,7 +593,7 @@
     "\n",
     "Runs `Cosmos3-Nano` once per robotics chunk through vLLM-Omni. Chunk 0 uses the DROID GT first frame. After each chunk finishes, the cell extracts that chunk's last generated frame and uses it as the conditioning image for the next chunk. Guardrails are disabled for this robotics run via `extra_params={\"guardrails\": false}`.\n",
     "\n",
-    "The request intentionally omits `size`, `width`, and `height`; Cosmos3/vLLM chooses the action canvas from `image_size=480` and preserves aspect ratio by padding.\n"
+    "Each request sets top-level `size` to the current conditioning image resolution so vLLM-Omni returns each autoregressive chunk without reflection padding.\n"
    ]
   },
   {
@@ -606,6 +610,7 @@
     "from pathlib import Path\n",
     "\n",
     "import imageio_ffmpeg\n",
+    "from PIL import Image\n",
     "\n",
     "try:\n",
     "    import requests\n",
@@ -639,6 +644,7 @@
     "    run_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "    vision_path = Path(record[\"vision_path\"])\n",
+    "    input_width, input_height = Image.open(vision_path).size\n",
     "    mime_type = mimetypes.guess_type(vision_path.name)[0] or \"application/octet-stream\"\n",
     "    extra_params = {\n",
     "        \"action_mode\": \"forward_dynamics\",\n",
@@ -657,6 +663,7 @@
     "        \"prompt\": prompt,\n",
     "        \"num_frames\": record[\"action_chunk_size\"] + 1,\n",
     "        \"fps\": record[\"fps\"],\n",
+    "        \"size\": f\"{input_width}x{input_height}\",\n",
     "        \"num_inference_steps\": 30,\n",
     "        \"guidance_scale\": 1.0,\n",
     "        \"flow_shift\": 10.0,\n",
@@ -994,7 +1001,7 @@
    "source": [
     "### Run UMI Autoregressive Forward-Dynamics Inference\n",
     "\n",
-    "Runs one vLLM-Omni video request per UMI action chunk. After each chunk completes, the cell extracts that chunk's last generated frame and uses it as the conditioning image for the next chunk."
+    "Runs one vLLM-Omni video request per UMI action chunk. After each chunk completes, the cell extracts that chunk's last generated frame and uses it as the conditioning image for the next chunk. Each request sets top-level `size` to the current conditioning image resolution to avoid reflection padding."
    ]
   },
   {
@@ -1011,6 +1018,7 @@
     "from pathlib import Path\n",
     "\n",
     "import imageio_ffmpeg\n",
+    "from PIL import Image\n",
     "\n",
     "try:\n",
     "    import requests\n",
@@ -1044,6 +1052,7 @@
     "    run_dir.mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "    vision_path = Path(record[\"vision_path\"])\n",
+    "    input_width, input_height = Image.open(vision_path).size\n",
     "    mime_type = mimetypes.guess_type(vision_path.name)[0] or \"application/octet-stream\"\n",
     "    extra_params = {\n",
     "        \"action_mode\": \"forward_dynamics\",\n",
@@ -1059,6 +1068,7 @@
     "        \"prompt\": prompt,\n",
     "        \"num_frames\": record[\"action_chunk_size\"] + 1,\n",
     "        \"fps\": record[\"fps\"],\n",
+    "        \"size\": f\"{input_width}x{input_height}\",\n",
     "        \"num_inference_steps\": 30,\n",
     "        \"guidance_scale\": 1.0,\n",
     "        \"flow_shift\": 10.0,\n",


### PR DESCRIPTION
Summary:
- Update the vLLM action cookbook to derive output resolution from input frames.
- Pass the computed width and height through the request payload.

Testing:
- Not run (not requested; notebook-only change).