### PR TITLE
docs: clarify PAIBench-C reproduction seed and prompt format

### DIFF
--- a/cookbooks/cosmos3/generator/transfer/README.md
+++ b/cookbooks/cosmos3/generator/transfer/README.md
@@ -34,6 +34,13 @@ come from the control video; see the spec field reference for how `fps` and
 
 Transfer inference is selected automatically when any hint key is present in the spec.
 
+> **PAIBench-C reproduction**: The checked-in specs (`specs/*.json`) with `--seed 2026`
+> are the canonical inference recipe used for the PAIBench-C results in the Cosmos3 report.
+> Prompts follow the structured `prompt.json` format shown in `assets/*/`. For the full
+> benchmark run, use the same per-clip seed (`2026`) for all clips. Evaluation
+> reproducibility is tracked separately at
+> [SHI-Labs/physical-ai-bench#7](https://github.com/SHI-Labs/physical-ai-bench/issues/7).
+
 ## Run with Cosmos Framework
 
 ### Quickstart


### PR DESCRIPTION
Closes https://github.com/NVIDIA/cosmos-framework/issues/14

Adds a clarifying note to the transfer cookbook README addressing the two remaining questions from bhack on the PAIBench-C reproducibility issue:

1. **Seed**: All clips use `--seed 2026` as the canonical reference seed
2. **Prompt format**: Prompts follow the structured `prompt.json` format shown in `assets/*/`

Remaining reproducibility gaps (prompt conversion, SAM2 determinism, evaluation) are tracked at https://github.com/NVIDIA/cosmos/issues/219.