### PR TITLE
docs: clarify action state and normalizer expectations

### DIFF
--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -42,6 +42,32 @@ fingers.
 
 Action data samples across different embodiments can be inspected interactively in the [Cosmos3 Action Viewer](https://huggingface.co/spaces/nvidia/Cosmos3-Action-Viewer) Hugging Face Space.
 
+### Dataset state, action layout, and normalization
+
+The inverse-dynamics examples predict action trajectories from video inputs.
+They do not infer a full LeRobot episode by themselves: fields such as
+`observation.state`, timestamps, frame indexes, and camera streams must come
+from the source dataset or the robot logging pipeline used to create the
+episode. When building a LeRobot-format dataset, align the predicted `action`
+rows with the original per-timestep observations instead of treating inverse
+dynamics as a replacement for state estimation.
+
+For a concrete LeRobot-style robotics sample, inspect
+[`assets/droid_lerobot_example/`](./assets/droid_lerobot_example/). Its
+metadata declares the DROID state streams
+`observation.state.cartesian_position`,
+`observation.state.joint_positions`, and
+`observation.state.gripper_position`, while the parquet/video assets provide the
+corresponding timestep-aligned records. This is the current checked-in example
+for understanding how action-conditioned robotics inputs relate to dataset
+state fields.
+
+Current checked-in action assets cover the AV, DROID, and UMI examples listed
+above. Use the action JSON files and notebooks as the canonical layout and
+normalization references for those examples. Other embodiment layouts and
+normalization statistics should be treated as model/data-release specific until
+their example assets are published.
+
 ## Run with Cosmos Framework
 
 ### Quickstart

--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -58,6 +58,33 @@ fingers.
 
 Action data samples across different embodiments can be inspected interactively in the [Cosmos3 Action Viewer](https://huggingface.co/spaces/nvidia/Cosmos3-Action-Viewer) Hugging Face Space.
 
+### Dataset state, action layout, and normalization
+
+The inverse-dynamics examples predict action trajectories from video inputs.
+They do not infer a full LeRobot episode by themselves: fields such as
+`observation.state`, timestamps, frame indexes, and camera streams must come
+from the source dataset or the robot logging pipeline used to create the
+episode. When building a LeRobot-format dataset, align the predicted `action`
+rows with the original per-timestep observations instead of treating inverse
+dynamics as a replacement for state estimation.
+
+For a concrete LeRobot-style robotics sample, inspect
+[`assets/droid_lerobot_example/`](./assets/droid_lerobot_example/). Its
+metadata declares the DROID state streams
+`observation.state.cartesian_position`,
+`observation.state.joint_positions`, and
+`observation.state.gripper_position`, while the parquet/video assets provide the
+corresponding timestep-aligned records. This is the current checked-in example
+for understanding how action-conditioned robotics inputs relate to dataset
+state fields.
+
+Use the action-definition table above as the current layout summary for the
+checked-in AV, DROID, UMI, and human hand-pose examples. The corresponding
+action JSON files and notebooks show how those layouts are normalized and passed
+to each backend. Other embodiment layouts and normalization statistics should be
+treated as model/data-release specific until their example assets or framework
+configuration are published.
+
 ## Run with Cosmos Framework
 
 ### Quickstart


### PR DESCRIPTION
Summary
- clarify that inverse dynamics predicts action trajectories but does not synthesize full LeRobot observation.state records
- point users to the checked-in DROID LeRobot sample metadata for timestep-aligned state streams
- document that current action-layout and normalization references are the checked-in AV, DROID, and UMI assets/notebooks until additional embodiment assets are released

Why
Issue #192 asks how to obtain observation.state alongside predicted actions for LeRobot-format episodes. Issue #184 asks for action channel layouts and normalizers across embodiments. This PR documents the current supported boundary and points to the concrete checked-in sample without claiming unreleased embodiment-specific layouts.

Testing
- git diff --check

Addresses #192
Related to #184