### PR TITLE
Add Cosmos3-Nano-Policy-DROID finetune cookbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,9 @@ outputs/
 cookbooks/cosmos3/generator/audiovisual/finetune/data/
 cookbooks/cosmos3/generator/audiovisual/finetune/checkpoints/
 cookbooks/cosmos3/generator/audiovisual/finetune/outputs/
+cookbooks/cosmos3/generator/action/finetune/data/
+cookbooks/cosmos3/generator/action/finetune/checkpoints/
+cookbooks/cosmos3/generator/action/finetune/outputs/
 cookbooks/cosmos3/reasoner/finetune/data/
 cookbooks/cosmos3/reasoner/finetune/checkpoints/
 cookbooks/cosmos3/reasoner/finetune/outputs/

--- a/README.md
+++ b/README.md
@@ -656,11 +656,12 @@ Cosmos 3 latency and serving numbers live in [`inference_benchmarks.md`](inferen
 
 ### Finetune
 
-Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookbooks below. Each recipe is a self-contained launch script: a single `bash launch_sft_<recipe>.sh` downloads the data, prepares the base checkpoint, and runs 8×H100 training.
+Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookbooks below. Each recipe is a self-contained launch script: a single `bash launch_sft_<recipe>.sh` prepares or validates the data, prepares the base checkpoint, and runs 8×H100 training.
 
 | Cookbook | Surface | Recipes |
 | --- | --- | --- |
 | [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Full SFT (Cosmos3-Nano) and LoRA SFT (Cosmos3-Super) on captioned video |
+| [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Full SFT (Cosmos3-Nano) for action policy on the DROID dataset |
 | [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Alignment SFT on LLaVA-OneVision and physical-plausibility SFT on VideoPhy-2 |
 
 These cookbooks run on the [Cosmos Framework](https://github.com/NVIDIA/cosmos-framework), NVIDIA's end-to-end Physical AI framework for training and serving world models. For the full post-training reference — every config field, raw `torchrun`, resuming, and advanced parallelism — see the [Cosmos Framework training guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/training.md).

--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -18,6 +18,7 @@ The rest of this doc shows how to run these modes on selected embodiments direct
 - [Run with vLLM-Omni](#run-with-vllm-omni)
   - [Quickstart](#quickstart-1)
   - [Notebook walkthrough](#notebook-walkthrough)
+- [Post-Train for Cosmos3-Nano-Policy-DROID](#post-train-for-cosmos3-nano-policy-droid)
 
 ## Overview
 
@@ -126,6 +127,13 @@ write outputs under `outputs/cosmos3_action_vllm/`:
   DROID, and UMI robotics examples.
 - [`run_id_with_vllm.ipynb`](./run_id_with_vllm.ipynb) — inverse dynamics,
   predicting ego-motion trajectories from input AV videos.
+
+## Post-Train for Cosmos3-Nano-Policy-DROID
+
+To reproduce our post-training recipe for [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID), use the
+[Cosmos3-Nano-Policy-DROID SFT cookbook](./finetune/README.md). It follows the same
+launch-script pattern as the other Cosmos3 finetune cookbooks while delegating
+the canonical training implementation to Cosmos Framework.
 
 
 

--- a/cookbooks/cosmos3/generator/action/finetune/README.md
+++ b/cookbooks/cosmos3/generator/action/finetune/README.md
@@ -1,0 +1,95 @@
+# Cosmos3-Nano-Policy-DROID Fine-Tuning (SFT)
+
+This example demonstrates supervised fine-tuning (SFT) of [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano) into an action policy for the DROID robot. It reproduces the post-training recipe used to create [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID), leveraging the public [Cosmos3-DROID](https://huggingface.co/datasets/nvidia/Cosmos3-DROID) dataset and the action-policy recipe from [cosmos-framework](https://github.com/NVIDIA/cosmos-framework).
+
+| Recipe | Launch shell | Base model | Dataset |
+| --- | --- | --- | --- |
+| Policy-DROID SFT | `launch_sft_action_policy_droid.sh` | Cosmos3-Nano | [Cosmos3-DROID](https://huggingface.co/datasets/nvidia/Cosmos3-DROID) success split |
+
+The recipe uses `[job].task = "vfm"` with the registered `action_policy_droid_nano` experiment. It trains a DROID policy model with `joint_pos` 8-D actions, proprioceptive state, `concat_view` 480p video, chunk length 32, episode-shuffle streaming, and the optional `keep_ranges_1_0_1.json` window filter.
+
+## Prerequisites
+
+1. **Install cosmos-framework.** This recipe drives `cosmos_framework.scripts.train`, so install a cosmos-framework checkout first — follow the shared [cosmos-framework setup](../../../README.md#cosmos-framework) (clone into `packages/cosmos3`, then `uv sync --all-extras --group=cu130-train`; use `cu128-train` on a CUDA 12.x driver).
+2. **Recommended container.** For a curated CUDA + PyTorch base, NVIDIA recommends starting from the NGC PyTorch container **`nvcr.io/nvidia/pytorch:25.09-py3`** (CUDA 13; use **`:25.06-py3`** for a CUDA 12.8 driver). See the cosmos-framework [setup guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/setup.md#recommended-base-image).
+3. **Activate** the cosmos-framework venv so `cosmos_framework` is importable: `source <path-to>/packages/cosmos3/.venv/bin/activate`.
+4. **Hugging Face access.** The base model, Wan2.2 VAE, Cosmos3-DROID dataset, and `keep_ranges_1_0_1.json` filter are hosted on Hugging Face — authenticate once with `uvx hf@latest auth login` (or export `HF_TOKEN`) and accept any model/dataset terms first.
+5. **Weights & Biases.** The TOML follows the canonical cosmos-framework example and defaults to `wandb_mode="online"`. Export `WANDB_API_KEY` for online logging, or add `job.wandb_mode=disabled` to `EXTRA_TAIL_OVERRIDES` for a local/no-W&B run.
+6. **Prepare the Cosmos3-DROID dataset.** The full Cosmos3-DROID dataset is large, so this cookbook expects you to stage it explicitly. By default the launcher looks for `data/Cosmos3-DROID/success/meta/info.json` under this folder. Set `DATASET_PATH=/path/to/Cosmos3-DROID/success` to use another filesystem.
+7. **Run from this directory** (`cookbooks/cosmos3/generator/action/finetune/`). Converted checkpoints, the Wan2.2 VAE, the `keep_ranges_1_0_1.json` filter, and run outputs default to `checkpoints/`, `data/`, and `outputs/` here (all git-ignored).
+
+## Quick start
+
+Stage the dataset, then run the launcher:
+
+```shell
+# One possible layout. The dataset is large; put it on a filesystem with enough space.
+uvx hf@latest download \
+    nvidia/Cosmos3-DROID \
+    --repo-type dataset \
+    --local-dir data/Cosmos3-DROID
+
+bash launch_sft_action_policy_droid.sh
+```
+
+The launcher is a complete local wrapper for the public cookbook:
+
+- checks that the Cosmos3-DROID success split exists
+- downloads `Wan2.2_VAE.pth` if needed
+- converts `Cosmos3-Nano` to a local DCP checkpoint if needed
+- downloads `keep_ranges_1_0_1.json` if needed
+- launches 8-GPU training with `action_policy_droid_repro.toml`
+
+The script intentionally stays close to the `cosmos-framework` example launcher: `DATASET_PATH`
+is bridged to `DROID_ROOT`, `BASE_CHECKPOINT_PATH` and `WAN_VAE_PATH` are exported for the TOML,
+`EXTRA_TAIL_OVERRIDES` is appended after `--`, and `NPROC_PER_NODE` / `NNODES` / `NODE_RANK` /
+`MASTER_ADDR` / `MASTER_PORT` map directly to `torchrun`. The extra cookbook behavior is the
+reasoner-style local prep above and enabling the released `keep_ranges_1_0_1.json` filter by default.
+
+Paths are fixed at the top of the script (under this git-ignored folder) — edit them there or export env vars to relocate data and checkpoints:
+
+```shell
+export DATASET_PATH=/scratch/Cosmos3-DROID/success
+export BASE_CHECKPOINT_PATH=/scratch/checkpoints/Cosmos3-Nano
+export WAN_VAE_PATH=/scratch/checkpoints/wan22_vae/Wan2.2_VAE.pth
+export FILTER_PATH=/scratch/droid/keep_ranges_1_0_1.json
+bash launch_sft_action_policy_droid.sh
+```
+
+To run a short smoke test, keep the same inputs and override the iteration/batch knobs:
+
+```shell
+export EXTRA_TAIL_OVERRIDES="job.wandb_mode=disabled trainer.max_iter=10 checkpoint.save_iter=10 dataloader_train.max_samples_per_batch=32"
+bash launch_sft_action_policy_droid.sh
+```
+
+## Outputs
+
+Training writes to `outputs/train/<project>/<group>/<name>/`:
+
+- `checkpoints/iter_<N>/` — DCP checkpoint (model / optim / scheduler / trainer state); `checkpoints/latest_checkpoint.txt` names the newest.
+- `config.yaml`, launch metadata, logs, and one directory per registered callback.
+
+## Export to Hugging Face safetensors
+
+```shell
+RUN_DIR=outputs/train/<project>/<group>/<name>
+CKPT=$RUN_DIR/checkpoints/$(cat "$RUN_DIR/checkpoints/latest_checkpoint.txt")
+python -m cosmos_framework.scripts.export_model \
+    --checkpoint-path "$CKPT" \
+    --config-file "$RUN_DIR/config.yaml" \
+    -o "$RUN_DIR/model"
+```
+
+Use the exported `$RUN_DIR/model` with the [Cosmos3-Nano-Policy-DROID inference cookbook](../run_policy_with_cosmos_framework.md).
+
+## Advanced configuration
+
+These recipes are intentionally minimal. For the full post-training reference — raw `torchrun`, resuming, every TOML field, the `keep_ranges_1_0_1.json` filter, and advanced HSDP/multi-node parallelism — see the canonical cosmos-framework docs:
+
+- [Cosmos3-Nano-Policy-DROID post-training guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/action_policy_droid_posttrain.md)
+- [Post-Training (SFT) guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/training.md)
+- [SFT structured-TOML config reference](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/sft_config.md)
+- [environment variables](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/environment_variables.md) · [FAQ / OOM during SFT](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/faq.md)
+
+> SFT here is a multi-GPU `torchrun` job, so this cookbook ships as a launch script + this README rather than a one-click notebook.

--- a/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid.sh
+++ b/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# Complete recipe: DROID action-policy SFT on Cosmos3-Nano (8x H100).
+# Run from this folder with the cosmos-framework venv active (see README):
+#   bash launch_sft_action_policy_droid.sh
+# It prepares the small dependencies, checks for the staged DROID dataset, and trains.
+# Paths are fixed under this (git-ignored) folder, matching the reasoner finetune
+# wrappers, while the TOML and tail-overrides match the cosmos-framework example.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+TOML_FILE="toml/sft_config/action_policy_droid_repro.toml"
+: "${DATASET_PATH:=$PWD/data/Cosmos3-DROID/success}"
+: "${BASE_CHECKPOINT_PATH:=$PWD/checkpoints/Cosmos3-Nano}"
+: "${WAN_VAE_PATH:=$PWD/checkpoints/wan22_vae/Wan2.2_VAE.pth}"
+: "${FILTER_PATH:=$PWD/data/droid_filters/keep_ranges_1_0_1.json}"
+
+# 1. The full DROID dataset is large, so require users to stage it explicitly.
+if [[ ! -f "$DATASET_PATH/meta/info.json" ]]; then
+    cat >&2 <<EOF
+ERROR: missing DROID dataset at:
+  $DATASET_PATH
+
+Expected a LeRobotDataset success split containing meta/info.json.
+Stage nvidia/Cosmos3-DROID first, or export DATASET_PATH=/path/to/Cosmos3-DROID/success.
+For example:
+  uvx hf@latest download --repo-type dataset nvidia/Cosmos3-DROID --local-dir data/Cosmos3-DROID
+EOF
+    exit 1
+fi
+
+# 2. Download the Wan2.2 VAE (skipped if present).
+if [[ ! -f "$WAN_VAE_PATH" ]]; then
+    uvx hf@latest download Wan-AI/Wan2.2-TI2V-5B Wan2.2_VAE.pth --local-dir "$(dirname "$WAN_VAE_PATH")"
+fi
+
+# 3. Convert the base checkpoint to DCP (skipped if present).
+if [[ ! -d "$BASE_CHECKPOINT_PATH" ]]; then
+    python -m cosmos_framework.scripts.convert_model_to_dcp -o "$BASE_CHECKPOINT_PATH" --checkpoint-path Cosmos3-Nano
+fi
+
+# 4. Download the keep-ranges filter used by the released reproduction recipe (skipped if present).
+if [[ ! -f "$FILTER_PATH" ]]; then
+    mkdir -p "$(dirname "$FILTER_PATH")"
+    uvx hf@latest download KarlP/droid keep_ranges_1_0_1.json --local-dir "$(dirname "$FILTER_PATH")"
+fi
+
+# 5. Train (8-GPU FSDP by default). The TOML reads these paths from the environment.
+export DROID_ROOT="${DROID_ROOT:-$DATASET_PATH}"
+export BASE_CHECKPOINT_PATH
+export WAN_VAE_PATH
+
+TAIL_OVERRIDES=(
+    "dataloader_train.dataloader.datasets.droid.dataset.use_filter_dict=True"
+    "dataloader_train.dataloader.datasets.droid.dataset.filter_dict_path=$FILTER_PATH"
+)
+if [[ -n "${EXTRA_TAIL_OVERRIDES:-}" ]]; then
+    # EXTRA_TAIL_OVERRIDES is intentionally word-split to match the framework launcher UX.
+    # shellcheck disable=SC2206
+    EXTRA_OVERRIDES_ARRAY=(${EXTRA_TAIL_OVERRIDES})
+    TAIL_OVERRIDES+=("${EXTRA_OVERRIDES_ARRAY[@]}")
+fi
+
+TORCHRUN_ARGS=(--nproc_per_node="${NPROC_PER_NODE:-8}")
+TORCHRUN_ARGS+=(--master_port="${MASTER_PORT:-50012}")
+[[ -n "${NNODES:-}" ]] && TORCHRUN_ARGS+=(--nnodes="$NNODES")
+[[ -n "${NODE_RANK:-}" ]] && TORCHRUN_ARGS+=(--node_rank="$NODE_RANK")
+[[ -n "${MASTER_ADDR:-}" ]] && TORCHRUN_ARGS+=(--master_addr="$MASTER_ADDR")
+
+OUTPUT_ROOT="${OUTPUT_ROOT:-$PWD/outputs/train}"
+IMAGINAIRE_OUTPUT_ROOT="${IMAGINAIRE_OUTPUT_ROOT:-$OUTPUT_ROOT}" torchrun "${TORCHRUN_ARGS[@]}" \
+    -m cosmos_framework.scripts.train --sft-toml="$TOML_FILE" \
+    -- "${TAIL_OVERRIDES[@]}"

--- a/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_droid_repro.toml
+++ b/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_droid_repro.toml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# ============================================================================
+# DROID action-policy SFT — run config for the `action_policy_droid_nano`
+# experiment. The recipe knobs (optimizer/lr, scheduler type, grad_clip,
+# count-based batch, action-head skip-on-load, dataset knobs) live in the
+# registered experiment; this file only sets run-level scalars (iters, ckpt
+# cadence, parallelism shape, wandb, VAE path).
+#
+# Env required:
+#   DROID_ROOT=/path/to/droid_lerobot_640x360/success
+#   BASE_CHECKPOINT_PATH=<Cosmos3-Nano DCP dir>
+#   WAN_VAE_PATH=<Wan2.2_VAE.pth>
+#   IMAGINAIRE_OUTPUT_ROOT=/path/to/output_root   # persist checkpoints
+# ============================================================================
+
+[job]
+task         = "vfm"
+experiment   = "action_policy_droid_nano"
+project      = "cosmos3_action"
+group        = "action_sft"
+name         = "action_policy_droid_repro"
+wandb_mode   = "online"
+
+[model]
+precision = "bfloat16"
+
+[model.parallelism]
+data_parallel_shard_degree     = 8    # 8-GPU model shard; set replicate for multi-node HSDP
+data_parallel_replicate_degree = 1
+
+[model.activation_checkpointing]
+mode           = "full"
+save_ops_regex = ["fmha"]
+
+[model.tokenizer]
+vae_path = "${oc.env:WAN_VAE_PATH}"
+
+[scheduler]
+cycle_lengths = [10000]   # match max_iter
+
+[trainer]
+max_iter     = 10000
+logging_iter = 50
+
+[checkpoint]
+load_path = "${oc.env:BASE_CHECKPOINT_PATH}"
+save_iter = 1000
+
+# max_samples_per_batch is 128 in the experiment — samples packed into each per-rank batch
+# (the num_workers x prefetch_factor workers just decode in parallel to keep it fed); res480,
+# reference recipe, validated multi-node on GB200.
+# On lower-memory GPUs, reduce it at launch, e.g.:
+#   --opts dataloader_train.max_samples_per_batch=32


### PR DESCRIPTION
## Summary
- Add a public Cosmos3-Nano-Policy-DROID finetune cookbook for Cosmos3-Nano.
- Add a launcher that validates staged DROID data, prepares the Wan2.2 VAE and base DCP checkpoint, then runs the framework SFT entrypoint.
- Add the TOML wrapper for the `action_policy_droid_nano` experiment and link it from the action cookbook docs.

## Validation
- `git diff --check origin/main...HEAD`
- `bash -n cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid.sh`
- Parsed `action_policy_droid_repro.toml` with `tomli` and verified experiment/shard/max_iter fields.