### PR TITLE
[codex] Fix RBench notebook root after generator move

### DIFF
--- a/evaluation/cosmos3/generator/rbench/run_with_cosmos_framework.ipynb
+++ b/evaluation/cosmos3/generator/rbench/run_with_cosmos_framework.ipynb
@@ -99,7 +99,7 @@
         "COSMOS3_NUM_GPUS = os.environ.get(\"COSMOS3_NUM_GPUS\", \"4\")\n",
         "CUDA_VISIBLE_DEVICES = os.environ.get(\"CUDA_VISIBLE_DEVICES\", \"0,1,2,3\")\n",
         "\n",
-        "RBENCH_NOTEBOOK_ROOT = COSMOS_ROOT / \"evaluation\" / \"rbench\"\n",
+        "RBENCH_NOTEBOOK_ROOT = COSMOS_ROOT / \"evaluation\" / \"cosmos3\" / \"generator\" / \"rbench\"\n",
         "RBENCH_ASSETS = RBENCH_NOTEBOOK_ROOT / \"assets\"\n",
         "RBENCH_PROMPTS_DIR = RBENCH_ASSETS / \"prompts\"\n",
         "RBENCH_HF_URL = os.environ.get(\"RBENCH_HF_URL\", \"https://huggingface.co/datasets/DAGroup-PKU/RBench\")\n",


### PR DESCRIPTION
## Summary
- Rebase onto latest `main`, which already moves RBench to `evaluation/cosmos3/generator/rbench`.
- Update the RBench notebook `RBENCH_NOTEBOOK_ROOT` so it resolves local assets from the new generator evaluation location.

## Validation
- `jq empty evaluation/cosmos3/generator/rbench/run_with_cosmos_framework.ipynb`
- `jq empty evaluation/cosmos3/generator/rbench/assets/prompts/*.json`
- Confirmed no stale old-location notebook/path references with `rg`.
- GitHub reports `mergeable: true` for PR #229.