### PR TITLE
Link to HF space viewer in action cookbook

### DIFF
--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -1,14 +1,29 @@
-# Cosmos3 Generator Action Examples
+# Cosmos3 Generator Action
 
-Cosmos3-Nano action-generation examples across two inference backends — native
+Cosmos3-Nano action-generation supports three distinct tasks:
+
+- **Forward dynamics (`fd`)** — predict future observations from a start image plus an action trajectory.
+- **Inverse dynamics (`id`)** — predict ego-motion trajectories from input AV or camera videos using the Cosmos3-Nano.
+- **Policy (`policy`)** — predict future observations and action trajectories from a start image, task instruction, and state.
+
+Each of the modes can be explored interactively using the [Action Viewer](https://huggingface.co/spaces/nvidia/Cosmos3-Action-Viewer) Hugging Face space.
+The rest of this doc shows how to run these modes on selected embodiments directly.
+
+## Table of Contents
+
+- [Overview](#examples-overview)
+- [Run with Cosmos Framework](#run-with-cosmos-framework)
+  - [Quickstart](#quickstart)
+  - [Cosmos Framework Walkthrough](#cosmos-framework-walkthrough)
+- [Run with vLLM-Omni](#run-with-vllm-omni)
+  - [Quickstart](#quickstart-1)
+  - [Notebook walkthrough](#notebook-walkthrough)
+
+## Overview
+
+All examples are shown across two different inference backends — native
 PyTorch (Cosmos Framework) and vLLM-Omni. Both backends use the sample assets
-under [`assets/`](./assets) and cover two tasks:
-
-- **Forward dynamics (`fd`)** — predict future observations from a start image
-  plus an action trajectory (AV, DROID, and UMI robotics examples) using the Cosmos3-Nano.
-- **Inverse dynamics (`id`)** — predict ego-motion trajectories from input AV
-  videos using the Cosmos3-Nano.
-- **Policy (`policy`)** — predict future observations and action trajectories from a start image, task instruction, and state for DROID robot using the Cosmos3-Nano-Policy-DROID.
+under [`assets/`](./assets) and cover three tasks:
 
 Environment setup for both backends is centralized in the shared
 [Cosmos3 cookbooks environment setup](../../README.md) guide; each backend below
@@ -19,16 +34,6 @@ Generator requires the Guardrail. Request access to the gated
 HF repository before running these examples. To disable the guardrail, set
 `enable_safety_checker=False` (Diffusers), `guardrails: false` (vLLM-Omni
 `extra_params`/`extra_args`), or `--no-guardrails` (Cosmos Framework).
-
-## Table of Contents
-
-- [Run with Cosmos Framework](#run-with-cosmos-framework)
-  - [Quickstart](#quickstart)
-  - [Cosmos Framework Walkthrough](#cosmos-framework-walkthrough)
-- [Run with vLLM-Omni](#run-with-vllm-omni)
-  - [Quickstart](#quickstart-1)
-  - [Notebook walkthrough](#notebook-walkthrough)
-
 
 ## Action Definition
 


### PR DESCRIPTION
Updates the action cookbook doc to provide a general overview of action generation and link to the HF space demonstrating the action modes.