### PR TITLE
docs: fix Overview TOC anchor in action generator README

### DIFF
--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -11,7 +11,7 @@ The rest of this doc shows how to run these modes on selected embodiments direct
 
 ## Table of Contents
 
-- [Overview](#examples-overview)
+- [Overview](#overview)
 - [Run with Cosmos Framework](#run-with-cosmos-framework)
   - [Quickstart](#quickstart)
   - [Cosmos Framework Walkthrough](#cosmos-framework-walkthrough)


### PR DESCRIPTION
The table of contents linked to #examples-overview but the section heading is ## Overview (#overview).