### PR TITLE
docs: expand Cosmos 3 finetune table and base reasoner SFT on Cosmos3-Nano

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,11 +771,11 @@ Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookb
 
 | Example | Surface | Model | What it covers | Script |
 | --- | --- | --- | --- | --- |
-| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT on captioned video | `launch_sft_vision_nano.sh` |
-| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Super | LoRA SFT on captioned video | `launch_sft_vision_super.sh` |
-| [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT for action policy on the DROID dataset | `launch_sft_action_policy_droid.sh` |
-| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Alignment SFT on LLaVA-OneVision | `launch_sft_llava_ov.sh` |
-| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Physical-plausibility SFT on VideoPhy-2 | `launch_sft_videophy2_nano.sh` |
+| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT on captioned video | [`launch_sft_vision_nano.sh`](cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_nano.sh) |
+| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Super | LoRA SFT on captioned video | [`launch_sft_vision_super.sh`](cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh) |
+| [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT for action policy on the DROID dataset | [`launch_sft_action_policy_droid.sh`](cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid.sh) |
+| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Alignment SFT on LLaVA-OneVision | [`launch_sft_llava_ov.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh) |
+| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Physical-plausibility SFT on VideoPhy-2 | [`launch_sft_videophy2_nano.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh) |
 
 These cookbooks run on the [Cosmos Framework](https://github.com/NVIDIA/cosmos-framework), NVIDIA's end-to-end Physical AI framework for training and serving world models. For the full post-training reference — every config field, raw `torchrun`, resuming, and advanced parallelism — see the [Cosmos Framework training guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/training.md).
 

--- a/README.md
+++ b/README.md
@@ -769,11 +769,13 @@ Cosmos 3 latency and serving numbers live in [`inference_benchmarks.md`](inferen
 
 Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookbooks below. Each recipe is a self-contained launch script: a single `bash launch_sft_<recipe>.sh` prepares or validates the data, prepares the base checkpoint, and runs 8×H100 training.
 
-| Cookbook | Surface | Recipes |
-| --- | --- | --- |
-| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Full SFT (Cosmos3-Nano) and LoRA SFT (Cosmos3-Super) on captioned video |
-| [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Full SFT (Cosmos3-Nano) for action policy on the DROID dataset |
-| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Alignment SFT on LLaVA-OneVision and physical-plausibility SFT on VideoPhy-2 |
+| Cookbook | Surface | Model | What it covers | Script |
+| --- | --- | --- | --- | --- |
+| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT on captioned video | `launch_sft_vision_nano.sh` |
+| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Super | LoRA SFT on captioned video | `launch_sft_vision_super.sh` |
+| [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT for action policy on the DROID dataset | `launch_sft_action_policy_droid.sh` |
+| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Alignment SFT on LLaVA-OneVision | `launch_sft_llava_ov.sh` |
+| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Physical-plausibility SFT on VideoPhy-2 | `launch_sft_videophy2_nano.sh` |
 
 These cookbooks run on the [Cosmos Framework](https://github.com/NVIDIA/cosmos-framework), NVIDIA's end-to-end Physical AI framework for training and serving world models. For the full post-training reference — every config field, raw `torchrun`, resuming, and advanced parallelism — see the [Cosmos Framework training guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/training.md).
 

--- a/README.md
+++ b/README.md
@@ -769,7 +769,7 @@ Cosmos 3 latency and serving numbers live in [`inference_benchmarks.md`](inferen
 
 Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookbooks below. Each recipe is a self-contained launch script: a single `bash launch_sft_<recipe>.sh` prepares or validates the data, prepares the base checkpoint, and runs 8×H100 training.
 
-| Cookbook | Surface | Model | What it covers | Script |
+| Example | Surface | Model | What it covers | Script |
 | --- | --- | --- | --- | --- |
 | [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT on captioned video | `launch_sft_vision_nano.sh` |
 | [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Super | LoRA SFT on captioned video | `launch_sft_vision_super.sh` |

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/README.md
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/README.md
@@ -29,6 +29,8 @@ bash launch_sft_vision_super.sh     # LoRA SFT on Cosmos3-Super
 
 Paths are fixed at the top of each script (under this git-ignored folder) — edit them there to put data or checkpoints on another filesystem.
 
+These recipes default to 8 GPUs. On a 4-GPU node (e.g. GB200×4), set `--nproc_per_node=4` on the `torchrun` line in the launch script.
+
 ## Outputs
 
 Training writes to `outputs/train/<project>/<group>/<name>/`:

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_nano.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_nano.sh
@@ -6,7 +6,7 @@
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_vision_nano.sh
 # It downloads the data, prepares the base checkpoint, and trains — in order.
-# Paths are fixed under this (git-ignored) folder; edit them below to relocate.
+# Paths are fixed under this folder; edit them below to relocate.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_nano.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_nano.sh
@@ -35,5 +35,6 @@ fi
 export DATASET_PATH="$DATASET_DIR/sft_dataset_bridge"
 export BASE_CHECKPOINT_PATH="$CHECKPOINT_DIR"
 export WAN_VAE_PATH="$VAE_PATH"
+# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/vision_sft_nano.toml"

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
@@ -38,5 +38,6 @@ export PYTORCH_ALLOC_CONF="expandable_segments:True"
 export DATASET_PATH="$DATASET_DIR/sft_dataset_bridge"
 export BASE_CHECKPOINT_PATH="$CHECKPOINT_DIR"
 export WAN_VAE_PATH="$VAE_PATH"
+# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead (CP=2 / DP=2).
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/vision_sft_super.toml"

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
@@ -38,6 +38,6 @@ export PYTORCH_ALLOC_CONF="expandable_segments:True"
 export DATASET_PATH="$DATASET_DIR/sft_dataset_bridge"
 export BASE_CHECKPOINT_PATH="$CHECKPOINT_DIR"
 export WAN_VAE_PATH="$VAE_PATH"
-# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead (CP=2 / DP=2).
+# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/vision_sft_super.toml"

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
@@ -6,7 +6,7 @@
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_vision_super.sh
 # It downloads the data, prepares the base checkpoint, and trains — in order.
-# Paths are fixed under this (git-ignored) folder; edit them below to relocate.
+# Paths are fixed under this folder; edit them below to relocate.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -29,6 +29,8 @@ bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + build
 
 The VideoPhy-2 download/convert steps are skipped once their outputs exist. Paths are fixed at the top of each script (under this git-ignored folder) — edit them there to relocate data or checkpoints.
 
+These recipes default to 8 GPUs. On a 4-GPU node (e.g. GB200×4), set `--nproc_per_node=4` on the `torchrun` line in the launch script.
+
 ## Outputs
 
 Training writes to `outputs/train/<project>/<group>/<name>/`:

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -1,13 +1,13 @@
 # Cosmos3 Reasoner Fine-Tuning (SFT)
 
-Supervised fine-tuning (SFT) of the Cosmos3 Reasoner (VLM) on your own data. Tested on 8×H100 (80 GB).
+Supervised fine-tuning (SFT) of the Cosmos3 Reasoner on your own data. Tested on 8×H100 (80 GB).
 
 | Recipe | Launch shell | Dataset | Notes |
 | --- | --- | --- | --- |
-| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; merged Cosmos3-Nano VLM checkpoint auto-built |
+| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; merged Cosmos3-Nano Reasoner checkpoint auto-built |
 | Physical-plausibility SFT (VideoPhy-2) | `launch_sft_videophy2_nano.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | 1–5 plausibility scoring; dataset + checkpoint auto-prepared |
 
-Both use `[job].task = "vlm"` and bootstrap from a merged Cosmos3-Nano VLM checkpoint, auto-built on first run.
+Both bootstrap from a merged Cosmos3-Nano Reasoner checkpoint, auto-built on first run.
 
 ## Prerequisites
 
@@ -22,9 +22,9 @@ Both use `[job].task = "vlm"` and bootstrap from a merged Cosmos3-Nano VLM check
 Each launcher is a complete recipe — just run it from this folder:
 
 ```shell
-bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, builds the merged Cosmos3-Nano VLM checkpoint, then trains
+bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, builds the merged Cosmos3-Nano Reasoner checkpoint, then trains
 # or
-bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the merged Cosmos3-Nano VLM checkpoint, then trains
+bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the merged Cosmos3-Nano Reasoner checkpoint, then trains
 ```
 
 The VideoPhy-2 download/convert steps are skipped once their outputs exist. Paths are fixed at the top of each script (under this git-ignored folder) — edit them there to relocate data or checkpoints.

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -4,10 +4,10 @@ Supervised fine-tuning (SFT) of the Cosmos3 Reasoner on your own data. Tested on
 
 | Recipe | Launch shell | Dataset | Notes |
 | --- | --- | --- | --- |
-| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; merged Cosmos3-Nano Reasoner checkpoint auto-built |
+| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; Cosmos3-Nano Reasoner checkpoint auto-built |
 | Physical-plausibility SFT (VideoPhy-2) | `launch_sft_videophy2_nano.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | 1–5 plausibility scoring; dataset + checkpoint auto-prepared |
 
-Both bootstrap from a merged Cosmos3-Nano Reasoner checkpoint, auto-built on first run.
+Both bootstrap from a Cosmos3-Nano Reasoner checkpoint, auto-built on first run.
 
 ## Prerequisites
 
@@ -22,9 +22,9 @@ Both bootstrap from a merged Cosmos3-Nano Reasoner checkpoint, auto-built on fir
 Each launcher is a complete recipe — just run it from this folder:
 
 ```shell
-bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, builds the merged Cosmos3-Nano Reasoner checkpoint, then trains
+bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, builds the Cosmos3-Nano Reasoner checkpoint, then trains
 # or
-bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the merged Cosmos3-Nano Reasoner checkpoint, then trains
+bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the Cosmos3-Nano Reasoner checkpoint, then trains
 ```
 
 The VideoPhy-2 download/convert steps are skipped once their outputs exist. Paths are fixed at the top of each script (under this git-ignored folder) — edit them there to relocate data or checkpoints.

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -4,17 +4,17 @@ Supervised fine-tuning (SFT) of the Cosmos3 Reasoner (VLM) on your own data. Tes
 
 | Recipe | Launch shell | Dataset | Notes |
 | --- | --- | --- | --- |
-| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; backbone fetched at startup — no local prep |
+| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; merged Cosmos3-Nano VLM checkpoint auto-built |
 | Physical-plausibility SFT (VideoPhy-2) | `launch_sft_videophy2_nano.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | 1–5 plausibility scoring; dataset + checkpoint auto-prepared |
 
-Both use `[job].task = "vlm"` and bootstrap from `Qwen/Qwen3-VL-8B-Instruct` (optionally a merged Cosmos3-Nano reasoner snapshot).
+Both use `[job].task = "vlm"` and bootstrap from a merged Cosmos3-Nano VLM checkpoint, auto-built on first run.
 
 ## Prerequisites
 
 1. **Install the framework.** These recipes drive `cosmos_framework.scripts.train`, so install a cosmos-framework checkout first — follow the shared [Cosmos Framework setup](../../README.md#cosmos-framework) (clone into `packages/cosmos3`, then `uv sync --all-extras --group=cu130-train`; use `cu128-train` on a CUDA 12.x driver).
 2. **Recommended container.** For a curated CUDA + PyTorch base, NVIDIA recommends starting from the NGC PyTorch container **`nvcr.io/nvidia/pytorch:25.09-py3`** (CUDA 13; use **`:25.06-py3`** for a CUDA 12.8 driver). See the framework [setup guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/setup.md#recommended-base-image).
 3. **Activate** the framework venv so `cosmos_framework` is importable: `source <path-to>/packages/cosmos3/.venv/bin/activate`.
-4. **Hugging Face access.** The Qwen3-VL backbone and datasets are fetched from HF — authenticate once with `uvx hf@latest auth login` (or export `HF_TOKEN`); accept any dataset terms first.
+4. **Hugging Face access.** The Cosmos3-Nano base checkpoint and datasets are fetched from HF — authenticate once with `uvx hf@latest auth login` (or export `HF_TOKEN`); accept any dataset terms first.
 5. **Run from this directory** (`cookbooks/cosmos3/reasoner/finetune/`). Any downloads, converted checkpoints, and run outputs default to `data/`, `checkpoints/`, and `outputs/` here (all git-ignored).
 
 ## Quick start
@@ -22,7 +22,7 @@ Both use `[job].task = "vlm"` and bootstrap from `Qwen/Qwen3-VL-8B-Instruct` (op
 Each launcher is a complete recipe — just run it from this folder:
 
 ```shell
-bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, backbone fetched at startup
+bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, builds the merged Cosmos3-Nano VLM checkpoint, then trains
 # or
 bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the merged Cosmos3-Nano VLM checkpoint, then trains
 ```

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -7,7 +7,7 @@ Supervised fine-tuning (SFT) of the Cosmos3 Reasoner on your own data. Tested on
 | Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; Cosmos3-Nano Reasoner checkpoint auto-built |
 | Physical-plausibility SFT (VideoPhy-2) | `launch_sft_videophy2_nano.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | 1–5 plausibility scoring; dataset + checkpoint auto-prepared |
 
-Both bootstrap from a Cosmos3-Nano Reasoner checkpoint, auto-built on first run.
+Both use `[job].task = "vlm"` and bootstrap from a Cosmos3-Nano Reasoner checkpoint, auto-built on first run.
 
 ## Prerequisites
 

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -15,7 +15,7 @@ Both bootstrap from a Cosmos3-Nano Reasoner checkpoint, auto-built on first run.
 2. **Recommended container.** For a curated CUDA + PyTorch base, NVIDIA recommends starting from the NGC PyTorch container **`nvcr.io/nvidia/pytorch:25.09-py3`** (CUDA 13; use **`:25.06-py3`** for a CUDA 12.8 driver). See the framework [setup guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/setup.md#recommended-base-image).
 3. **Activate** the framework venv so `cosmos_framework` is importable: `source <path-to>/packages/cosmos3/.venv/bin/activate`.
 4. **Hugging Face access.** The Cosmos3-Nano base checkpoint and datasets are fetched from HF — authenticate once with `uvx hf@latest auth login` (or export `HF_TOKEN`); accept any dataset terms first.
-5. **Run from this directory** (`cookbooks/cosmos3/reasoner/finetune/`). Any downloads, converted checkpoints, and run outputs default to `data/`, `checkpoints/`, and `outputs/` here (all git-ignored).
+5. **Run from this directory** (`cookbooks/cosmos3/reasoner/finetune/`). Any downloads, converted checkpoints, and run outputs default to `data/`, `checkpoints/`, and `outputs/` here.
 
 ## Quick start
 
@@ -27,7 +27,7 @@ bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, b
 bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the Cosmos3-Nano Reasoner checkpoint, then trains
 ```
 
-The VideoPhy-2 download/convert steps are skipped once their outputs exist. Paths are fixed at the top of each script (under this git-ignored folder) — edit them there to relocate data or checkpoints.
+The VideoPhy-2 download/convert steps are skipped once their outputs exist. Paths are fixed at the top of each script — edit them there to relocate data or checkpoints.
 
 These recipes default to 8 GPUs. On a 4-GPU node (e.g. GB200×4), set `--nproc_per_node=4` on the `torchrun` line in the launch script.
 

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -4,10 +4,10 @@ Supervised fine-tuning (SFT) of the Cosmos3 Reasoner on your own data. Tested on
 
 | Recipe | Launch shell | Dataset | Notes |
 | --- | --- | --- | --- |
-| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; Cosmos3-Nano Reasoner checkpoint auto-built |
+| Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; Cosmos3-Nano Reasoner checkpoint auto-prepared |
 | Physical-plausibility SFT (VideoPhy-2) | `launch_sft_videophy2_nano.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | 1–5 plausibility scoring; dataset + checkpoint auto-prepared |
 
-Both use `[job].task = "vlm"` and bootstrap from a Cosmos3-Nano Reasoner checkpoint, auto-built on first run.
+Both use `[job].task = "vlm"` and bootstrap from a Cosmos3-Nano Reasoner checkpoint, auto-prepared on first run.
 
 ## Prerequisites
 

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
@@ -5,12 +5,22 @@
 # Complete recipe: Reasoner alignment SFT on LLaVA-OneVision (8x H100).
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_llava_ov.sh
-# The dataset streams from HuggingFace and the Qwen3-VL-8B-Instruct backbone is
-# fetched at startup, so there's nothing to download first — this just trains.
+# The dataset streams from HuggingFace, so there's nothing to download first. It
+# builds the merged Cosmos3-Nano VLM checkpoint, then trains — in order. Paths
+# are fixed under this (git-ignored) folder.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Train (8-GPU FSDP).
+VLM_CHECKPOINT="$PWD/checkpoints/Cosmos3-Nano-VLM"
+
+# 1. Build the merged Cosmos3-Nano VLM checkpoint (skipped if present).
+if [[ ! -d "$VLM_CHECKPOINT" ]]; then
+    python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$VLM_CHECKPOINT"
+fi
+
+# 2. Train (8-GPU FSDP). The merged checkpoint is supplied as a config override
+#    after `--`.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
-    -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/llava_ov.toml"
+    -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/llava_ov.toml" \
+    -- model.config.policy.backbone.safetensors_path="$VLM_CHECKPOINT"

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
@@ -7,7 +7,7 @@
 #   bash launch_sft_llava_ov.sh
 # The dataset streams from HuggingFace, so there's nothing to download first. It
 # builds the Cosmos3-Nano Reasoner checkpoint, then trains — in order. Paths
-# are fixed under this (git-ignored) folder.
+# are fixed under this folder.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
@@ -21,6 +21,7 @@ fi
 
 # 2. Train (8-GPU FSDP). The merged checkpoint is supplied as a config override
 #    after `--`.
+# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/llava_ov.toml" \
     -- model.config.policy.backbone.safetensors_path="$VLM_CHECKPOINT"

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
@@ -6,17 +6,17 @@
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_llava_ov.sh
 # The dataset streams from HuggingFace, so there's nothing to download first. It
-# builds the merged Cosmos3-Nano VLM checkpoint, then trains — in order. Paths
+# builds the merged Cosmos3-Nano Reasoner checkpoint, then trains — in order. Paths
 # are fixed under this (git-ignored) folder.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-VLM_CHECKPOINT="$PWD/checkpoints/Cosmos3-Nano-VLM"
+REASONER_CHECKPOINT="$PWD/checkpoints/Cosmos3-Nano-Reasoner"
 
-# 1. Build the merged Cosmos3-Nano VLM checkpoint (skipped if present).
-if [[ ! -d "$VLM_CHECKPOINT" ]]; then
-    python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$VLM_CHECKPOINT"
+# 1. Build the merged Cosmos3-Nano Reasoner checkpoint (skipped if present).
+if [[ ! -d "$REASONER_CHECKPOINT" ]]; then
+    python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$REASONER_CHECKPOINT"
 fi
 
 # 2. Train (8-GPU FSDP). The merged checkpoint is supplied as a config override
@@ -24,4 +24,4 @@ fi
 # On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/llava_ov.toml" \
-    -- model.config.policy.backbone.safetensors_path="$VLM_CHECKPOINT"
+    -- model.config.policy.backbone.safetensors_path="$REASONER_CHECKPOINT"

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh
@@ -6,7 +6,7 @@
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_llava_ov.sh
 # The dataset streams from HuggingFace, so there's nothing to download first. It
-# builds the merged Cosmos3-Nano Reasoner checkpoint, then trains — in order. Paths
+# builds the Cosmos3-Nano Reasoner checkpoint, then trains — in order. Paths
 # are fixed under this (git-ignored) folder.
 
 set -euo pipefail
@@ -14,12 +14,12 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 REASONER_CHECKPOINT="$PWD/checkpoints/Cosmos3-Nano-Reasoner"
 
-# 1. Build the merged Cosmos3-Nano Reasoner checkpoint (skipped if present).
+# 1. Build the Cosmos3-Nano Reasoner checkpoint (skipped if present).
 if [[ ! -d "$REASONER_CHECKPOINT" ]]; then
     python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$REASONER_CHECKPOINT"
 fi
 
-# 2. Train (8-GPU FSDP). The merged checkpoint is supplied as a config override
+# 2. Train (8-GPU FSDP). The checkpoint is supplied as a config override
 #    after `--`.
 # On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
@@ -27,6 +27,7 @@ fi
 # 3. Train (8-GPU FSDP). VIDEOPHYSICS_ROOT is read from the environment; the
 #    merged checkpoint is supplied as a config override after `--`.
 export VIDEOPHYSICS_ROOT
+# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/videophy2_sft_nano.toml" \
     -- model.config.policy.backbone.safetensors_path="$VLM_CHECKPOINT"

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
@@ -19,7 +19,7 @@ if [[ ! -d "$VIDEOPHYSICS_ROOT/videophy2_train" ]]; then
     python -m cosmos_framework.scripts.vlm.prepare_videophy2_from_hf --out_root "$VIDEOPHYSICS_ROOT" --split both
 fi
 
-# 2. Merge Cosmos3-Nano LM onto the Qwen3-VL-8B-Instruct visual tower (skipped if present).
+# 2. Build the merged Cosmos3-Nano VLM checkpoint (skipped if present).
 if [[ ! -d "$VLM_CHECKPOINT" ]]; then
     python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$VLM_CHECKPOINT"
 fi

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
@@ -6,7 +6,7 @@
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_videophy2_nano.sh
 # It materializes the dataset, builds the Cosmos3-Nano Reasoner checkpoint, and
-# trains — in order. Paths are fixed under this (git-ignored) folder.
+# trains — in order. Paths are fixed under this folder.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
@@ -5,23 +5,23 @@
 # Complete recipe: Reasoner physical-plausibility SFT on VideoPhy-2 (8x H100).
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_videophy2_nano.sh
-# It materializes the dataset, builds the merged Cosmos3-Nano VLM checkpoint, and
+# It materializes the dataset, builds the merged Cosmos3-Nano Reasoner checkpoint, and
 # trains — in order. Paths are fixed under this (git-ignored) folder.
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 VIDEOPHYSICS_ROOT="$PWD/data/videophysics"
-VLM_CHECKPOINT="$PWD/checkpoints/Cosmos3-Nano-VLM"
+REASONER_CHECKPOINT="$PWD/checkpoints/Cosmos3-Nano-Reasoner"
 
 # 1. Materialize the VideoPhy-2 dataset (skipped if present).
 if [[ ! -d "$VIDEOPHYSICS_ROOT/videophy2_train" ]]; then
     python -m cosmos_framework.scripts.vlm.prepare_videophy2_from_hf --out_root "$VIDEOPHYSICS_ROOT" --split both
 fi
 
-# 2. Build the merged Cosmos3-Nano VLM checkpoint (skipped if present).
-if [[ ! -d "$VLM_CHECKPOINT" ]]; then
-    python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$VLM_CHECKPOINT"
+# 2. Build the merged Cosmos3-Nano Reasoner checkpoint (skipped if present).
+if [[ ! -d "$REASONER_CHECKPOINT" ]]; then
+    python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$REASONER_CHECKPOINT"
 fi
 
 # 3. Train (8-GPU FSDP). VIDEOPHYSICS_ROOT is read from the environment; the
@@ -30,4 +30,4 @@ export VIDEOPHYSICS_ROOT
 # On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/videophy2_sft_nano.toml" \
-    -- model.config.policy.backbone.safetensors_path="$VLM_CHECKPOINT"
+    -- model.config.policy.backbone.safetensors_path="$REASONER_CHECKPOINT"

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh
@@ -5,7 +5,7 @@
 # Complete recipe: Reasoner physical-plausibility SFT on VideoPhy-2 (8x H100).
 # Run from this folder with the cosmos-framework venv active (see README):
 #   bash launch_sft_videophy2_nano.sh
-# It materializes the dataset, builds the merged Cosmos3-Nano Reasoner checkpoint, and
+# It materializes the dataset, builds the Cosmos3-Nano Reasoner checkpoint, and
 # trains — in order. Paths are fixed under this (git-ignored) folder.
 
 set -euo pipefail
@@ -19,13 +19,13 @@ if [[ ! -d "$VIDEOPHYSICS_ROOT/videophy2_train" ]]; then
     python -m cosmos_framework.scripts.vlm.prepare_videophy2_from_hf --out_root "$VIDEOPHYSICS_ROOT" --split both
 fi
 
-# 2. Build the merged Cosmos3-Nano Reasoner checkpoint (skipped if present).
+# 2. Build the Cosmos3-Nano Reasoner checkpoint (skipped if present).
 if [[ ! -d "$REASONER_CHECKPOINT" ]]; then
     python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Nano -o "$REASONER_CHECKPOINT"
 fi
 
 # 3. Train (8-GPU FSDP). VIDEOPHYSICS_ROOT is read from the environment; the
-#    merged checkpoint is supplied as a config override after `--`.
+#    checkpoint is supplied as a config override after `--`.
 export VIDEOPHYSICS_ROOT
 # On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \


### PR DESCRIPTION
## Summary

Documentation/recipe updates to the Cosmos 3 fine-tuning (SFT) cookbooks and the README Finetune section.

- **README Finetune table** restructured to mirror the Inference Benchmarks table: one row per recipe, with `Model` and `Script` columns and `What it covers` replacing `Recipes`. The header column is renamed `Cookbook` → `Example`, and each `Script` cell links to its launch script.
- **Reasoner alignment SFT now trains from Cosmos3-Nano.** `launch_sft_llava_ov.sh` builds the merged Cosmos3-Nano VLM checkpoint and supplies it via `safetensors_path` (matching `launch_sft_videophy2_nano.sh`) instead of the bare backbone. Cookbook README and script comments updated; user-facing prose no longer references the Qwen backbone.
- **4-GPU note.** All four launch scripts and both cookbook READMEs note that 4-GPU nodes (e.g. GB200×4) can set `--nproc_per_node=4` instead of the default 8. The note is identical across all four scripts.

## Notes

- The two `model_name = "Qwen/Qwen3-VL-8B-Instruct"` lines in the TOMLs are left as-is — they are the HF id the framework uses to instantiate the VLM processor/architecture; weights come from the Cosmos3-Nano `safetensors_path` override.
- All launch scripts pass `bash -n`.

## Commits

- `docs: expand finetune table and base reasoner SFT on Cosmos3-Nano`
- `docs: note --nproc_per_node=4 for 4-GPU nodes (e.g. GB200x4)`
- `docs: rename finetune table header Cookbook -> Example`
- `docs: link Script column cells to launch scripts in finetune table`
- `docs: drop CP/DP detail from vision_super 4-GPU note`

🤖 Generated with [Claude Code](https://claude.com/claude-code)