### PR TITLE
docs: fix Notebook walkthrough TOC anchor in action README

### DIFF
--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -17,7 +17,7 @@ The rest of this doc shows how to run these modes on selected embodiments direct
   - [Cosmos Framework Walkthrough](#cosmos-framework-walkthrough)
 - [Run with vLLM-Omni](#run-with-vllm-omni)
   - [Quickstart](#quickstart-1)
-  - [Notebook walkthrough](#notebook-walkthrough)
+  - [Notebook walkthrough](#vllm-omni-notebook-walkthrough)
 - [Post-Train for Cosmos3-Nano-Policy-DROID](#post-train-for-cosmos3-nano-policy-droid)
 
 ## Overview


### PR DESCRIPTION
The table of contents linked to #notebook-walkthrough but the section heading is ### VLLM-Omni Notebook Walkthrough (#vllm-omni-notebook-walkthrough).