### PR TITLE
feat: add multi-control transfer inference

### DIFF
--- a/cookbooks/cosmos3/generator/transfer/README.md
+++ b/cookbooks/cosmos3/generator/transfer/README.md
@@ -10,6 +10,7 @@ Sample assets under [`assets/`](./assets) cover spatial control signals paired w
 - **Depth** — depth map control plus caption.
 - **Segmentation** — segmentation map control plus caption.
 - **World scenario (WSM)** — world-scenario map control plus caption.
+- **Multi-control** — two or more hints combined with per-hint weights.
 
 vLLM-Omni does not expose transfer controls today.
 
@@ -18,12 +19,12 @@ Environment setup is centralized in the shared
 
 ## Transfer Definition
 
-Video transfer generates a target clip from a `prompt.json` caption and a precomputed
-control video on the hint block (`control_path`). Inference uses `model_mode` `video2video`;
-there is no `vision_path` or source RGB video at run time. Output frame count and geometry
-come from the control video; see the spec field reference for how `fps` and
-`aspect_ratio` are resolved. All examples share
-`assets/negative_prompt.json` for the negative caption.
+Video transfer generates a target clip from a `prompt.json` caption and one or more
+spatial control signals. Inference uses `model_mode` `video2video`. Control signals can
+be supplied as pre-computed videos (`control_path`) or derived on-the-fly from a raw
+source video (`vision_path`). Output frame count and geometry come from the control
+video; see the spec field reference for how `fps` and `aspect_ratio` are resolved.
+All examples share `assets/negative_prompt.json` for the negative caption.
 
 | Control | Asset folder | Inference input | Generation duration |
 | --- | --- | --- | --- |
@@ -32,6 +33,7 @@ come from the control video; see the spec field reference for how `fps` and
 | Depth | `assets/depth/` | `control_depth.mp4` + `prompt.json` | 121 frames @ 30 FPS |
 | Segmentation | `assets/seg/` | `control_seg.mp4` + `prompt.json` | 121 frames @ 30 FPS |
 | World scenario (WSM) | `assets/wsm/` | `control_wsm.mp4` + `prompt.json` | 101 frames @ 10 FPS |
+| Multi-control | `assets/multi_control/` | `vision_path` + multiple hints | 121 frames @ 30 FPS |
 
 Transfer inference is selected automatically when any hint key is present in the spec.
 The same spec files are used for both Nano and Super — model selection is controlled
@@ -39,7 +41,7 @@ entirely by `--checkpoint-path`.
 
 ## Run with Cosmos Framework
 
-### Quickstart
+### Quickstart — Single-control transfer
 
 Set up the environment: [Cosmos Framework setup](../../README.md#cosmos-framework).
 Run the commands below inside the **cosmos container** (e.g. `pytorch:25.09-py3`) — the same
@@ -106,12 +108,13 @@ name, e.g. `outputs/Cosmos3-Nano/transfer_edge/vision.mp4`.
 
 [`run_video_transfer_with_cosmos_framework.ipynb`](./run_video_transfer_with_cosmos_framework.ipynb)
 is a self-contained tutorial: it installs all dependencies (system packages, framework
-clone, Python venv via `uv`), authenticates with Hugging Face, and runs all five controls
+clone, Python venv via `uv`), authenticates with Hugging Face, and runs all six controls
 with previews.
 
 1. Open the notebook and edit **§2 (Configure)** — paste your `HF_TOKEN` and optionally
    set cache/output paths.
-2. Run **§9–§13** for Cosmos3-Nano (single GPU) or **§14–§18** for Cosmos3-Super (multi-GPU).
+2. Run **§9–§13** for Cosmos3-Nano single-control (single GPU), **§14–§18** for Cosmos3-Super
+   single-control (multi-GPU), or **§19** for multi-control (Nano).
    No model flag needed — each section uses its matching checkpoint explicitly.
 
 To execute headlessly:
@@ -123,7 +126,133 @@ jupyter execute run_video_transfer_with_cosmos_framework.ipynb
 
 Outputs land under `outputs/notebooks/<model>/transfer_<control>/vision.mp4`.
 
-### Spec field reference
+---
+
+## Multi-Control Transfer
+
+Multi-control transfer blends two or more spatial hint streams — for example edge + depth
+— into a single generation pass. Each active hint receives a `weight` that determines its
+relative influence. Weights across all active hints should sum to 1.0 for predictable
+behavior, though the model accepts any positive values.
+
+### Concepts
+
+| Field | Description |
+| --- | --- |
+| `edge` / `blur` / `depth` / `seg` | Hint block; set any subset to activate those controls |
+| `weight` | Per-hint blending weight; ratios matter, not absolute values (default `1.0`) |
+| `control_path` | Path to a **pre-computed** control video (optional; see below) |
+| `vision_path` | Raw source video; the framework derives all active controls on-the-fly |
+| `control_guidance` | Global CFG scale across all active control streams (default `1.5`) |
+
+**Two input modes:**
+
+1. **`vision_path` mode** — Provide a raw source video. For `edge` and `blur` hints
+   with no `control_path`, the framework computes the control signal on-the-fly
+   (Canny for `edge`, downscale/upscale for `blur`). `depth` and `seg` always require
+   a pre-computed `control_path` — they depend on DepthAnything and SAM2 which are
+   not bundled in the cosmos-framework.
+
+2. **Pre-computed mode** — Provide a `control_path` inside each hint block. All
+   control videos must be derived from the **same source video** and share identical
+   resolution, fps, and frame count. Use this when you want exact control over the
+   pre-processed signals or to reuse cached extractions across runs.
+
+### Quickstart — Multi-control from a source video
+
+Uses the same env vars as the single-control quickstart (`COSMOS_FRAMEWORK` and `TRANSFER_ROOT`).
+
+#### Cosmos3-Nano (single GPU)
+
+```bash
+cd "$COSMOS_FRAMEWORK"
+
+# edge + blur computed on-the-fly from vision_path (robot_pouring.mp4)
+CUDA_VISIBLE_DEVICES=0 \
+.venv/bin/python -m cosmos_framework.scripts.inference \
+  --parallelism-preset=latency \
+  -i "$TRANSFER_ROOT/specs/multi_control.json" \
+  -o "$TRANSFER_ROOT/outputs/Cosmos3-Nano/" \
+  --checkpoint-path Cosmos3-Nano \
+  --seed 2026
+```
+
+Output lands at `outputs/Cosmos3-Nano/transfer_multi_control/vision.mp4`.
+
+#### Cosmos3-Super (multi-GPU)
+
+```bash
+cd "$COSMOS_FRAMEWORK"
+
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
+.venv/bin/torchrun --nproc-per-node=4 \
+  --master-addr=127.0.0.1 --master-port=29500 \
+  -m cosmos_framework.scripts.inference \
+  --parallelism-preset=latency \
+  -i "$TRANSFER_ROOT/specs/multi_control.json" \
+  -o "$TRANSFER_ROOT/outputs/Cosmos3-Super/" \
+  --checkpoint-path Cosmos3-Super \
+  --seed 2026
+```
+
+Output lands at `outputs/Cosmos3-Super/transfer_multi_control/vision.mp4`.
+
+### Spec field reference — multi-control
+
+**`specs/multi_control.json`** (edge dominant + blur secondary, controls derived on-the-fly from `vision_path`):
+
+```json
+{
+  "name": "transfer_multi_control",
+  "model_mode": "video2video",
+  "resolution": "720",
+  "aspect_ratio": "16,9",
+  "num_frames": 121,
+  "fps": 30,
+  "guidance": 3.0,
+  "control_guidance": 1.5,
+  "negative_prompt_file": "../assets/negative_prompt.json",
+  "prompt_path": "../assets/multi_control/prompt.json",
+  "vision_path": "https://.../robot_pouring.mp4",
+  "edge": {
+    "weight": 0.75,
+    "preset_edge_threshold": "medium"
+  },
+  "blur": {
+    "weight": 0.25,
+    "preset_blur_strength": "medium"
+  }
+}
+```
+
+Only the **ratio** between weights matters — `edge: 3, blur: 1` is equivalent to
+`edge: 0.75, blur: 0.25`. Omitting `weight` defaults to `1.0` (equal contribution).
+
+To use **pre-computed control videos** instead, replace `vision_path` with `control_path`
+inside each hint block. All control videos must be derived from the same source and
+share identical resolution, fps, and frame count:
+
+```json
+{
+  "edge": {
+    "control_path": "/path/to/control_edge.mp4",
+    "weight": 0.75,
+    "preset_edge_threshold": "medium"
+  },
+  "blur": {
+    "control_path": "/path/to/control_blur.mp4",
+    "weight": 0.25,
+    "preset_blur_strength": "medium"
+  }
+}
+```
+
+`control_guidance` scales the influence of all active control streams collectively;
+`weight` distributes that influence among individual hints.
+
+---
+
+### Spec field reference — single-control
 
 A representative spec (`specs/edge.json`):
 
@@ -163,7 +292,7 @@ Key fields:
 ### Cookbook entrypoints
 
 - [`run_video_transfer_with_cosmos_framework.ipynb`](./run_video_transfer_with_cosmos_framework.ipynb) —
-  self-contained notebook: §9–§13 Nano (single GPU), §14–§18 Super (multi-GPU). Edit §2, run top-to-bottom.
+  self-contained notebook: §9–§13 Nano single-control, §14–§18 Super single-control, §19 multi-control (Nano). Edit §2, run top-to-bottom.
 - [`specs/`](./specs) — checked-in Framework input JSON per control (paths relative to `specs/`).
   Shared by both Nano and Super.
 

--- a/cookbooks/cosmos3/generator/transfer/assets/multi_control/prompt.json
+++ b/cookbooks/cosmos3/generator/transfer/assets/multi_control/prompt.json
@@ -1,0 +1,44 @@
+{
+  "subjects": [
+    {
+      "description": "A white robotic arm with black joints and cables holding a small light-green pitcher",
+      "appearance_details": "Sleek white finish with visible mechanical joints, gripper holding a translucent pitcher containing clear liquid",
+      "relationship": "Central subject performing a precision pouring task above a glass on the table",
+      "location": "Center foreground",
+      "relative_size": "Large within frame",
+      "orientation": "Extended forward, slightly tilted to pour",
+      "pose": "Mid-pour with gripper angled downward",
+      "action": "Carefully pouring liquid into a glass"
+    },
+    {
+      "description": "A clear glass partially filled with a reddish-brown liquid on a white tabletop",
+      "appearance_details": "Transparent glass with a metal spoon inside, reddish-brown liquid filling the lower half",
+      "relationship": "Target vessel receiving the liquid poured by the robot arm",
+      "location": "Center below the robot gripper",
+      "relative_size": "Small within frame",
+      "pose": "Stationary on the table"
+    }
+  ],
+  "background_setting": "A clean, modern indoor setting with a white table surface and soft ambient lighting. A vase with white flowers and a brown couch are partially visible in the background.",
+  "lighting": {
+    "conditions": "Bright indoor lighting",
+    "direction": "Top-front diffused",
+    "shadows": "Soft shadows cast on the white tabletop"
+  },
+  "aesthetics": {
+    "composition": "Medium close-up emphasizing the robot gripper and the glass",
+    "color_scheme": "Clean whites and grays with warm accent tones from the liquid and background",
+    "mood_atmosphere": "Precise, controlled, clinical"
+  },
+  "cinematography": {
+    "camera_motion": "Static",
+    "framing": "Medium shot",
+    "camera_angle": "Slightly above eye-level looking down at the table"
+  },
+  "style_medium": "Live-action video",
+  "artistic_style": "Realistic robotics demonstration",
+  "resolution": {"W": 1280, "H": 720},
+  "aspect_ratio": "16,9",
+  "duration": "4s",
+  "fps": 30
+}

--- a/cookbooks/cosmos3/generator/transfer/preview_helpers.py
+++ b/cookbooks/cosmos3/generator/transfer/preview_helpers.py
@@ -98,10 +98,11 @@ def make_preview(src: Path, crf: int = 28) -> Path:
 def preview_transfer(control: str, *, model: str | None = None) -> None:
     """Preview control input and generated output for *control*.
 
-    *model* selects which output directory to read (``Cosmos3-Nano`` uses
-    ``<output_root>/<control>/…``; ``Cosmos3-Super`` uses
-    ``<output_root>/<control>_super/…``).  Defaults to the
-    ``COSMOS3_MODEL`` environment variable, falling back to ``Cosmos3-Nano``.
+    *model* selects which output directory to read — e.g. ``Cosmos3-Nano`` or
+    ``Cosmos3-Super``.  Output is read from
+    ``<output_root>/<model>/transfer_<control>/vision.mp4``.
+    Defaults to the ``COSMOS3_MODEL`` environment variable, falling back to
+    ``Cosmos3-Nano``.
     """
     resolved_model = model or os.environ.get("COSMOS3_MODEL", "Cosmos3-Nano")
     spec = load_transfer_spec(control)
@@ -122,6 +123,48 @@ def preview_transfer(control: str, *, model: str | None = None) -> None:
         preview = make_preview(src)
         print(
             f"{control} {label}: {src.name} "
+            f"({src.stat().st_size // 1024} KB -> {preview.stat().st_size // 1024} KB preview)"
+        )
+        if display is not None and Video is not None:
+            display(Video(str(preview), embed=True))
+        else:
+            print(f"  preview path: {preview}")
+
+
+def preview_multi_control(*, model: str | None = None) -> None:
+    """Preview computed control signals and the generated output for multi-control transfer.
+
+    *model* selects which output directory to read (e.g. ``Cosmos3-Nano`` or ``Cosmos3-Super``).
+    Defaults to the ``COSMOS3_MODEL`` environment variable, falling back to ``Cosmos3-Nano``.
+    """
+    resolved_model = model or os.environ.get("COSMOS3_MODEL", "Cosmos3-Nano")
+    out_dir = _output_root() / resolved_model / "transfer_multi_control"
+    vision_path = out_dir / "vision.mp4"
+    if not vision_path.is_file():
+        raise FileNotFoundError(
+            f"missing output: {vision_path}\n"
+            "Run the multi-control inference cell first (§19)."
+        )
+
+    try:
+        from IPython.display import Video, display
+    except ImportError:
+        display = None
+        Video = None
+
+    control_videos = [
+        ("edge control (computed on-the-fly)", out_dir / "control_edge.mp4"),
+        ("blur control (computed on-the-fly)", out_dir / "control_blur.mp4"),
+        ("generated output", vision_path),
+    ]
+
+    for label, src in control_videos:
+        if not src.is_file():
+            print(f"[skip] {label}: {src} not found")
+            continue
+        preview = make_preview(src)
+        print(
+            f"{label}: {src.name} "
             f"({src.stat().st_size // 1024} KB -> {preview.stat().st_size // 1024} KB preview)"
         )
         if display is not None and Video is not None:

--- a/cookbooks/cosmos3/generator/transfer/run_video_transfer_with_cosmos_framework.ipynb
+++ b/cookbooks/cosmos3/generator/transfer/run_video_transfer_with_cosmos_framework.ipynb
@@ -1,1296 +1,1490 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "license-header",
-   "metadata": {},
-   "source": [
-    "<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
-    "SPDX-License-Identifier: OpenMDW-1.1 -->"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-title",
-   "metadata": {},
-   "source": [
-    "# Cosmos3 Transfer with Cosmos Framework\n",
-    "\n",
-    "This notebook runs Cosmos3 **video transfer** inference through the native Cosmos Framework PyTorch entrypoint:\n",
-    "\n",
-    "```bash\n",
-    "python -m cosmos_framework.scripts.inference\n",
-    "```\n",
-    "\n",
-    "Transfer generates a target clip from a caption (`prompt.json`) and a spatial control video. Supported controls:\n",
-    "\n",
-    "- **edge** — Canny edge map (`control_edge.mp4`)\n",
-    "- **blur** — blurred reference (`control_blur.mp4`)\n",
-    "- **depth** — depth map (`control_depth.mp4`)\n",
-    "- **seg** — segmentation map (`control_seg.mp4`)\n",
-    "- **wsm** — world-scenario map (`control_wsm.mp4`)\n",
-    "\n",
-    "Run all Cosmos3-Nano examples first (§9–§13), then run the Cosmos3-Super examples (§14–§18) with the same control assets.\n",
-    "\n",
-    "| Model | Launcher | Parallelism | GPUs |\n",
-    "|---|---|---|---|\n",
-    "| Cosmos3-Nano | `python` (single GPU) | `latency` | 1 |\n",
-    "| Cosmos3-Super | `torchrun` (multi-GPU) | `throughput` | 4+ |\n",
-    "\n",
-    "> **GPU required.** Run on a host where §3 (`nvidia-smi`) and §7 (`cuda available: True`) both pass.\n",
-    "\n",
-    "**Self-contained setup:** everything needed (system packages, clone, Python venv) is in §2–§7 — no external bootstrap scripts required.\n",
-    "\n",
-    "Workflow: §2 configure → §3 GPU check → §4 system packages → §5 clone framework → §6 install → §7 verify → §8 review specs → §9–§13 Nano inference → §14–§18 Super inference.\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-prereq-md",
-   "metadata": {},
-   "source": [
-    "## 1. Prerequisites\n",
-    "\n",
-    "1. Linux machine with an NVIDIA GPU.\n",
-    "2. A [Hugging Face account](https://huggingface.co) with access to the Cosmos3 model repos — paste your token into **§2 below**.\n",
-    "3. `git` available on PATH (§5 clones Cosmos Framework when missing).\n",
-    "4. Outbound internet for `git clone`, PyPI (`uv sync` in §6), and HF checkpoint downloads.\n",
-    "\n",
-    "Everything else — system packages, framework clone, Python venv — is installed automatically by §4–§6.\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-config-md",
-   "metadata": {},
-   "source": [
-    "## 2. Configure\n",
-    "\n",
-    "**Edit the cell directly below** — it is the only cell you need to change before running the notebook top to bottom.\n",
-    "\n",
-    "| Setting | What it controls |\n",
-    "|---|---|\n",
-    "| `HF_TOKEN` | Hugging Face token for downloading model weights |\n",
-    "| `COSMOS3_CACHE_ROOT` | Path for uv + HF caches (leave `\"\"` to use default under this cookbook) |\n",
-    "| `COSMOS3_TRANSFER_OUTPUT_ROOT` | Where generated videos are saved (leave `\"\"` for default) |\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aabc169f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ── Edit here, then run all cells ──────────────────────────────────────────\n",
-    "\n",
-    "# Hugging Face token — required to download Cosmos3 weights.\n",
-    "# Get yours at https://huggingface.co/settings/tokens\n",
-    "HF_TOKEN = \"\"  # e.g. \"hf_xxxxxxxxxxxxxxxxxxxxxxxx\"\n",
-    "\n",
-    "# Cache root for uv and Hugging Face downloads.\n",
-    "# Set to a large disk, e.g. \"/lustre/scratch/cache\". Leave \"\" for default.\n",
-    "COSMOS3_CACHE_ROOT = \"\"\n",
-    "\n",
-    "# Output directory for generated videos. Leave \"\" for default.\n",
-    "COSMOS3_TRANSFER_OUTPUT_ROOT = \"\"\n",
-    "\n",
-    "# ── Push to environment (do not edit below this line) ───────────────────────\n",
-    "import os\n",
-    "if HF_TOKEN:\n",
-    "    os.environ[\"HF_TOKEN\"] = HF_TOKEN\n",
-    "if COSMOS3_CACHE_ROOT:\n",
-    "    os.environ[\"COSMOS3_CACHE_ROOT\"] = COSMOS3_CACHE_ROOT\n",
-    "if COSMOS3_TRANSFER_OUTPUT_ROOT:\n",
-    "    os.environ[\"COSMOS3_TRANSFER_OUTPUT_ROOT\"] = COSMOS3_TRANSFER_OUTPUT_ROOT\n",
-    "print(f\"cache: {COSMOS3_CACHE_ROOT or '(default)'}\")\n",
-    "print(f\"HF_TOKEN: {'set' if HF_TOKEN else 'not set — using existing hf login session'}\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7e454b75",
-   "metadata": {},
-   "source": [
-    "## 3. Confirm GPU access\n",
-    "\n",
-    "Run this **before** install (§6) or inference (§9+). If it fails, fix GPU allocation or driver setup before continuing."
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "transfer-config-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:32.302245Z",
-     "iopub.status.busy": "2026-06-09T04:27:32.302116Z",
-     "iopub.status.idle": "2026-06-09T04:27:32.323514Z",
-     "shell.execute_reply": "2026-06-09T04:27:32.323165Z"
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
+        "SPDX-License-Identifier: OpenMDW-1.1 -->"
+      ],
+      "id": "license-header"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Cosmos3 Transfer with Cosmos Framework\n",
+        "\n",
+        "This notebook runs Cosmos3 **video transfer** inference through the native Cosmos Framework PyTorch entrypoint:\n",
+        "\n",
+        "```bash\n",
+        "python -m cosmos_framework.scripts.inference\n",
+        "```\n",
+        "\n",
+        "Transfer generates a target clip from a caption (`prompt.json`) and one or more spatial control videos. Supported controls:\n",
+        "\n",
+        "- **edge** — Canny edge map (`control_edge.mp4`)\n",
+        "- **blur** — blurred reference (`control_blur.mp4`)\n",
+        "- **depth** — depth map (`control_depth.mp4`)\n",
+        "- **seg** — segmentation map (`control_seg.mp4`)\n",
+        "- **wsm** — world-scenario map (`control_wsm.mp4`)\n",
+        "- **multi-control** — two or more hints blended in a single pass (§19)\n",
+        "\n",
+        "Run Cosmos3-Nano single-control examples (§9–§13), Cosmos3-Super single-control examples (§14–§18), or the multi-control example (§19, Nano).\n",
+        "\n",
+        "| Model | Launcher | Parallelism | GPUs |\n",
+        "|---|---|---|---|\n",
+        "| Cosmos3-Nano | `python` (single GPU) | `latency` | 1 |\n",
+        "| Cosmos3-Super | `torchrun` (multi-GPU) | `latency` | 4+ |\n",
+        "\n",
+        "> **GPU required.** Run on a host where §3 (`nvidia-smi`) and §7 (`cuda available: True`) both pass.\n",
+        "\n",
+        "**Self-contained setup:** everything needed (system packages, clone, Python venv) is in §2–§7 — no external bootstrap scripts required.\n",
+        "\n",
+        "Workflow: §2 configure → §3 GPU check → §4 system packages → §5 clone framework → §6 install → §7 verify → §8 review specs → §9–§13 Nano single-control → §14–§18 Super single-control → §19 multi-control (Nano).\n"
+      ],
+      "id": "transfer-title"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Prerequisites\n",
+        "\n",
+        "1. Linux machine with an NVIDIA GPU.\n",
+        "2. A [Hugging Face account](https://huggingface.co) with access to the Cosmos3 model repos — paste your token into **§2 below**.\n",
+        "3. `git` available on PATH (§5 clones Cosmos Framework when missing).\n",
+        "4. Outbound internet for `git clone`, PyPI (`uv sync` in §6), and HF checkpoint downloads.\n",
+        "\n",
+        "Everything else — system packages, framework clone, Python venv — is installed automatically by §4–§6.\n"
+      ],
+      "id": "transfer-prereq-md"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Configure\n",
+        "\n",
+        "**Edit the cell directly below** — it is the only cell you need to change before running the notebook top to bottom.\n",
+        "\n",
+        "| Setting | What it controls |\n",
+        "|---|---|\n",
+        "| `HF_TOKEN` | Hugging Face token for downloading model weights |\n",
+        "| `COSMOS3_CACHE_ROOT` | Path for uv + HF caches (leave `\"\"` to use default under this cookbook) |\n",
+        "| `COSMOS3_TRANSFER_OUTPUT_ROOT` | Where generated videos are saved (leave `\"\"` for default) |\n"
+      ],
+      "id": "transfer-config-md"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# ── Edit here, then run all cells ──────────────────────────────────────────\n",
+        "\n",
+        "# Hugging Face token — required to download Cosmos3 weights.\n",
+        "# Get yours at https://huggingface.co/settings/tokens\n",
+        "HF_TOKEN = \"\"  # e.g. \"hf_xxxxxxxxxxxxxxxxxxxxxxxx\"\n",
+        "\n",
+        "# Cache root for uv and Hugging Face downloads.\n",
+        "# Set to a large disk, e.g. \"/lustre/scratch/cache\". Leave \"\" for default.\n",
+        "COSMOS3_CACHE_ROOT = \"\"\n",
+        "\n",
+        "# Output directory for generated videos. Leave \"\" for default.\n",
+        "COSMOS3_TRANSFER_OUTPUT_ROOT = \"\"\n",
+        "\n",
+        "# ── Push to environment (do not edit below this line) ───────────────────────\n",
+        "import os\n",
+        "if HF_TOKEN:\n",
+        "    os.environ[\"HF_TOKEN\"] = HF_TOKEN\n",
+        "if COSMOS3_CACHE_ROOT:\n",
+        "    os.environ[\"COSMOS3_CACHE_ROOT\"] = COSMOS3_CACHE_ROOT\n",
+        "if COSMOS3_TRANSFER_OUTPUT_ROOT:\n",
+        "    os.environ[\"COSMOS3_TRANSFER_OUTPUT_ROOT\"] = COSMOS3_TRANSFER_OUTPUT_ROOT\n",
+        "print(f\"cache: {COSMOS3_CACHE_ROOT or '(default)'}\")\n",
+        "print(f\"HF_TOKEN: {'set' if HF_TOKEN else 'not set — using existing hf login session'}\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "aabc169f"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Confirm GPU access\n",
+        "\n",
+        "Run this **before** install (§6) or inference (§9+). If it fails, fix GPU allocation or driver setup before continuing."
+      ],
+      "id": "7e454b75"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:32.302245Z",
+          "iopub.status.busy": "2026-06-09T04:27:32.302116Z",
+          "iopub.status.idle": "2026-06-09T04:27:32.323514Z",
+          "shell.execute_reply": "2026-06-09T04:27:32.323165Z"
+        }
+      },
+      "source": [
+        "from pathlib import Path\n",
+        "import json\n",
+        "import os\n",
+        "import platform\n",
+        "import socket\n",
+        "\n",
+        "\n",
+        "def find_repo_root(start: Path) -> Path:\n",
+        "    for path in [start, *start.parents]:\n",
+        "        if (path / \"README.md\").exists() and (path / \"cookbooks\").exists():\n",
+        "            return path\n",
+        "    return start\n",
+        "\n",
+        "\n",
+        "def free_local_port() -> str:\n",
+        "    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:\n",
+        "        sock.bind((\"127.0.0.1\", 0))\n",
+        "        return str(sock.getsockname()[1])\n",
+        "\n",
+        "\n",
+        "def default_framework_repo(root: Path) -> Path:\n",
+        "    for candidate in (root / \"packages\" / \"cosmos-framework\", root / \"packages\" / \"cosmos3\"):\n",
+        "        if (candidate / \"pyproject.toml\").exists() and (candidate / \"cosmos_framework\").exists():\n",
+        "            return candidate\n",
+        "    return root / \"packages\" / \"cosmos3\"\n",
+        "\n",
+        "\n",
+        "COSMOS_ROOT = find_repo_root(Path.cwd().resolve())\n",
+        "COSMOS3_TRANSFER_ROOT = COSMOS_ROOT / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "COSMOS3_REPO = Path(os.environ.get(\"COSMOS3_REPO\", default_framework_repo(COSMOS_ROOT))).resolve()\n",
+        "COSMOS3_GIT_URL = os.environ.get(\n",
+        "    \"COSMOS3_GIT_URL\",\n",
+        "    \"https://github.com/NVIDIA/cosmos-framework.git\",\n",
+        ")\n",
+        "def default_uv_group() -> str:\n",
+        "    # cu128-train attention wheels are x86_64-only; aarch64 hosts need cu130-train for natten.\n",
+        "    if platform.machine() == \"aarch64\":\n",
+        "        return \"cu130-train\"\n",
+        "    return \"cu128-train\"\n",
+        "\n",
+        "\n",
+        "COSMOS3_UV_GROUP = os.environ.get(\"COSMOS3_UV_GROUP\", default_uv_group())\n",
+        "COSMOS3_TRANSFER_OUTPUT_ROOT = Path(\n",
+        "    os.environ.get(\n",
+        "        \"COSMOS3_TRANSFER_OUTPUT_ROOT\",\n",
+        "        COSMOS3_TRANSFER_ROOT / \"outputs\" / \"notebooks\",\n",
+        "    )\n",
+        ").resolve()\n",
+        "COSMOS3_SPECS_DIR = COSMOS3_TRANSFER_ROOT / \"specs\"\n",
+        "TRANSFER_CONTROLS = (\"edge\", \"blur\", \"depth\", \"seg\", \"wsm\")\n",
+        "\n",
+        "\n",
+        "def _detect_gpu_count() -> str:\n",
+        "    \"\"\"Count visible GPUs via nvidia-smi; fall back to 4.\"\"\"\n",
+        "    import subprocess\n",
+        "    try:\n",
+        "        out = subprocess.check_output(\n",
+        "            [\"nvidia-smi\", \"--query-gpu=name\", \"--format=csv,noheader\"],\n",
+        "            timeout=10, stderr=subprocess.DEVNULL,\n",
+        "        ).decode()\n",
+        "        count = len([l for l in out.strip().splitlines() if l])\n",
+        "        if count > 0:\n",
+        "            return str(count)\n",
+        "    except Exception:\n",
+        "        pass\n",
+        "    return \"4\"\n",
+        "\n",
+        "\n",
+        "COSMOS3_NUM_GPUS = os.environ.get(\"COSMOS3_NUM_GPUS\") or _detect_gpu_count()\n",
+        "\n",
+        "os.environ[\"COSMOS_ROOT\"] = str(COSMOS_ROOT)\n",
+        "os.environ[\"COSMOS3_TRANSFER_ROOT\"] = str(COSMOS3_TRANSFER_ROOT)\n",
+        "os.environ[\"COSMOS3_REPO\"] = str(COSMOS3_REPO)\n",
+        "os.environ[\"COSMOS3_GIT_URL\"] = COSMOS3_GIT_URL\n",
+        "os.environ[\"COSMOS3_UV_GROUP\"] = COSMOS3_UV_GROUP\n",
+        "os.environ[\"COSMOS3_TRANSFER_OUTPUT_ROOT\"] = str(COSMOS3_TRANSFER_OUTPUT_ROOT)\n",
+        "os.environ[\"COSMOS3_NUM_GPUS\"] = COSMOS3_NUM_GPUS\n",
+        "\n",
+        "\n",
+        "def default_cache_path(name: str) -> str:\n",
+        "    root = os.environ.get(\"COSMOS3_CACHE_ROOT\")\n",
+        "    if root:\n",
+        "        return str((Path(root).expanduser() / name).resolve())\n",
+        "    return str((COSMOS3_TRANSFER_ROOT / \".cache\" / name).resolve())\n",
+        "\n",
+        "\n",
+        "os.environ[\"UV_CACHE_DIR\"] = os.environ.get(\"COSMOS3_UV_CACHE_DIR\", default_cache_path(\"uv\"))\n",
+        "os.environ[\"HF_HOME\"] = os.environ.get(\"COSMOS3_HF_HOME\", default_cache_path(\"huggingface\"))\n",
+        "# NGC PyTorch images: clear bundled libtorch from LD_LIBRARY_PATH before inference.\n",
+        "os.environ.pop(\"LD_LIBRARY_PATH\", None)\n",
+        "# Default CUDA_VISIBLE_DEVICES to all detected GPUs so both Nano and Super cells work.\n",
+        "_all_gpus = \",\".join(str(i) for i in range(int(COSMOS3_NUM_GPUS)))\n",
+        "os.environ.setdefault(\"CUDA_VISIBLE_DEVICES\", _all_gpus)\n",
+        "os.environ.setdefault(\"COSMOS3_MASTER_ADDR\", \"127.0.0.1\")\n",
+        "os.environ.setdefault(\"COSMOS3_MASTER_PORT\", free_local_port())\n",
+        "\n",
+        "print(\"cosmos root:\", COSMOS_ROOT)\n",
+        "print(\"transfer cookbook:\", COSMOS3_TRANSFER_ROOT)\n",
+        "print(\"framework:\", COSMOS3_REPO)\n",
+        "print(\"controls:\", \", \".join(TRANSFER_CONTROLS))\n",
+        "print(\"output root:\", COSMOS3_TRANSFER_OUTPUT_ROOT)\n",
+        "print(\"UV_CACHE_DIR:\", os.environ[\"UV_CACHE_DIR\"])\n",
+        "print(\"HF_HOME:\", os.environ[\"HF_HOME\"])\n",
+        "print(\"COSMOS3_UV_GROUP:\", os.environ[\"COSMOS3_UV_GROUP\"])\n",
+        "print(\"COSMOS3_NUM_GPUS:\", os.environ[\"COSMOS3_NUM_GPUS\"])\n",
+        "print(\"CUDA_VISIBLE_DEVICES:\", os.environ[\"CUDA_VISIBLE_DEVICES\"])\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "transfer-config-code"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:32.324823Z",
+          "iopub.status.busy": "2026-06-09T04:27:32.324648Z",
+          "iopub.status.idle": "2026-06-09T04:27:32.577517Z",
+          "shell.execute_reply": "2026-06-09T04:27:32.577151Z"
+        }
+      },
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "echo \"hostname: $(hostname)\"\n",
+        "echo \"CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-<unset>}\"\n",
+        "if ! command -v nvidia-smi >/dev/null 2>&1; then\n",
+        "  echo \"ERROR: nvidia-smi not found. Run on a GPU host (see §1).\"\n",
+        "  exit 1\n",
+        "fi\n",
+        "nvidia-smi -L\n",
+        "GPU_COUNT=$(nvidia-smi -L 2>/dev/null | wc -l)\n",
+        "if [ \"${GPU_COUNT:-0}\" -lt 1 ]; then\n",
+        "  echo \"ERROR: no GPUs visible. Allocate a GPU or set CUDA_VISIBLE_DEVICES.\"\n",
+        "  exit 1\n",
+        "fi\n",
+        "echo \"OK: ${GPU_COUNT} GPU(s) visible on $(hostname)\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7e649ded"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Install system packages (Linux)\n",
+        "\n",
+        "Framework guardrails and previews need **ffmpeg**, **git-lfs**, and graphics libraries (`libxcb1`, `libgl1`, …). On hosts with `apt-get` (NGC PyTorch container, many training images), run the next cell to install them.\n",
+        "\n",
+        "If `apt-get` is unavailable, install the same packages with your OS package manager — see [Cosmos3 cookbooks README — System packages](../../README.md#system-packages-required-for-framework-guardrails).\n"
+      ],
+      "id": "transfer-system-md"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:32.578847Z",
+          "iopub.status.busy": "2026-06-09T04:27:32.578702Z",
+          "iopub.status.idle": "2026-06-09T04:27:36.082056Z",
+          "shell.execute_reply": "2026-06-09T04:27:36.081698Z"
+        }
+      },
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "\n",
+        "PACKAGES=(curl ffmpeg git-lfs libgl1 libglib2.0-0 libx11-dev libxcb1 tree wget)\n",
+        "\n",
+        "if command -v apt-get >/dev/null 2>&1; then\n",
+        "  export DEBIAN_FRONTEND=noninteractive\n",
+        "  echo \"Installing system packages via apt-get...\"\n",
+        "  apt-get update -qq\n",
+        "  apt-get install -y --no-install-recommends \"${PACKAGES[@]}\"\n",
+        "  echo \"OK: apt packages installed\"\n",
+        "else\n",
+        "  echo \"NOTE: apt-get not found on this host.\"\n",
+        "  echo \"If guardrails or OpenCV fail with libxcb.so.1, install manually:\"\n",
+        "  echo \"  ${PACKAGES[*]}\"\n",
+        "  echo \"See cookbooks/cosmos3/README.md (Framework guardrails).\"\n",
+        "fi\n",
+        "\n",
+        "for cmd in git ffmpeg; do\n",
+        "  command -v \"$cmd\" >/dev/null || { echo \"ERROR: missing $cmd\"; exit 1; }\n",
+        "done\n",
+        "if command -v git-lfs >/dev/null 2>&1; then\n",
+        "  git lfs install --skip-repo 2>/dev/null || true\n",
+        "  echo \"git-lfs: OK\"\n",
+        "else\n",
+        "  echo \"WARN: git-lfs not in PATH (uv sync may still work with GIT_LFS_SKIP_SMUDGE=1)\"\n",
+        "fi\n",
+        "echo \"System package check complete.\""
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "320ddc9d"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Clone Cosmos Framework\n",
+        "\n",
+        "Clones `COSMOS3_GIT_URL` into `COSMOS3_REPO` when the tree is not already present."
+      ],
+      "id": "5f79a744"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:36.083352Z",
+          "iopub.status.busy": "2026-06-09T04:27:36.083225Z",
+          "iopub.status.idle": "2026-06-09T04:27:36.789163Z",
+          "shell.execute_reply": "2026-06-09T04:27:36.788823Z"
+        }
+      },
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "\n",
+        "mkdir -p \"$(dirname \"$COSMOS3_REPO\")\"\n",
+        "\n",
+        "if [ -d \"$COSMOS3_REPO/.git\" ]; then\n",
+        "  echo \"Using existing framework checkout: $COSMOS3_REPO\"\n",
+        "elif [ -f \"$COSMOS3_REPO/pyproject.toml\" ] && [ -d \"$COSMOS3_REPO/cosmos_framework\" ]; then\n",
+        "  echo \"Using existing framework tree (no .git): $COSMOS3_REPO\"\n",
+        "else\n",
+        "  echo \"Cloning $COSMOS3_GIT_URL into $COSMOS3_REPO\"\n",
+        "  git clone \"$COSMOS3_GIT_URL\" \"$COSMOS3_REPO\"\n",
+        "fi\n",
+        "\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "if [ -d .git ]; then\n",
+        "  git status --short --branch\n",
+        "  git remote -v\n",
+        "fi\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "transfer-clone-code"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Install Cosmos Framework Dependencies\n",
+        "\n",
+        "Installs [`uv`](https://docs.astral.sh/uv/) if missing, then runs `uv sync` to create `packages/cosmos3/.venv`. Uses `COSMOS3_UV_GROUP` from §2.\n",
+        "\n",
+        "**Skip:** if `.venv` already imports `cosmos_framework` with CUDA available, the next cell skips `uv sync` (fast re-runs). Set `COSMOS3_FORCE_UV_SYNC=1` to force a full re-sync.\n",
+        "\n",
+        "For `jupyter execute` on a GPU node, set `COSMOS3_UV_CACHE_DIR` / `COSMOS3_HF_HOME` (or `COSMOS3_CACHE_ROOT`) in §2 first.\n",
+        "\n",
+        "If you change `COSMOS3_UV_GROUP`, **re-run this cell** before inference.\n"
+      ],
+      "id": "transfer-install-md"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:36.790397Z",
+          "iopub.status.busy": "2026-06-09T04:27:36.790279Z",
+          "iopub.status.idle": "2026-06-09T04:27:46.484277Z",
+          "shell.execute_reply": "2026-06-09T04:27:46.483864Z"
+        }
+      },
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "\n",
+        "if ! command -v uv >/dev/null 2>&1; then\n",
+        "  echo \"Installing uv...\"\n",
+        "  curl -LsSf https://astral.sh/uv/install.sh | sh\n",
+        "  # shellcheck disable=SC1091\n",
+        "  source \"${HOME}/.local/bin/env\" 2>/dev/null || export PATH=\"${HOME}/.local/bin:${PATH}\"\n",
+        "fi\n",
+        "uv self update 2>/dev/null || true\n",
+        "uv --version\n",
+        "\n",
+        "export GIT_LFS_SKIP_SMUDGE=1\n",
+        "mkdir -p \"$UV_CACHE_DIR\" \"$HF_HOME\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "export UV_CACHE_DIR=\"${UV_CACHE_DIR:?set paths in §2 (run the configure cell first)}\"\n",
+        "export UV_PROJECT_ENVIRONMENT=\"${UV_PROJECT_ENVIRONMENT:-$COSMOS3_REPO/.venv}\"\n",
+        "export UV_HTTP_TIMEOUT=\"${UV_HTTP_TIMEOUT:-600}\"\n",
+        "echo \"UV_CACHE_DIR=$UV_CACHE_DIR\"\n",
+        "echo \"COSMOS3_UV_GROUP=$COSMOS3_UV_GROUP\"\n",
+        "echo \"UV_HTTP_TIMEOUT=$UV_HTTP_TIMEOUT\"\n",
+        "\n",
+        "if [ -z \"${COSMOS3_FORCE_UV_SYNC:-}\" ] && [ -x \".venv/bin/python\" ]; then\n",
+        "  if env -u LD_LIBRARY_PATH .venv/bin/python -c \\\n",
+        "      'import cosmos_framework, torch; assert torch.cuda.is_available()'; then\n",
+        "    echo \"venv ready at $COSMOS3_REPO/.venv — skipping uv sync (set COSMOS3_FORCE_UV_SYNC=1 to re-sync)\"\n",
+        "    uv pip install imageio imageio-ffmpeg\n",
+        "    env -u LD_LIBRARY_PATH .venv/bin/python -c \\\n",
+        "      'import cosmos_framework, torch; print(\"venv OK (skipped sync)\")'\n",
+        "    exit 0\n",
+        "  fi\n",
+        "  echo \"Existing .venv failed CUDA/framework check — running full uv sync...\"\n",
+        "fi\n",
+        "\n",
+        "attempt=1\n",
+        "max_attempts=3\n",
+        "until uv sync --all-extras --group=\"$COSMOS3_UV_GROUP\"; do\n",
+        "  if [ \"$attempt\" -ge \"$max_attempts\" ]; then\n",
+        "    echo \"ERROR: uv sync failed after $max_attempts attempts (PyPI timeout or network).\"\n",
+        "    exit 1\n",
+        "  fi\n",
+        "  echo \"uv sync attempt $attempt failed; retrying in 30s...\"\n",
+        "  attempt=$((attempt + 1))\n",
+        "  sleep 30\n",
+        "done\n",
+        "\n",
+        "uv pip install imageio imageio-ffmpeg\n",
+        "\n",
+        "env -u LD_LIBRARY_PATH .venv/bin/python -c \\\n",
+        "  'import cosmos_framework, torch; assert torch.cuda.is_available(); print(\"venv OK\")'\n",
+        "echo \"Install complete: $COSMOS3_REPO/.venv\"\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "transfer-install-code"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6.5. Authenticate with Hugging Face\n",
+        "\n",
+        "Downloads Cosmos3 weights from Hugging Face during first inference. This cell uses `HF_TOKEN` from §2 if set, or falls back to an existing `hf login` session.\n"
+      ],
+      "id": "transfer-hf-auth-md"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "\n",
+        "HF_BIN=\"$COSMOS3_REPO/.venv/bin/huggingface-cli\"\n",
+        "[ -x \"$HF_BIN\" ] || HF_BIN=$(command -v huggingface-cli 2>/dev/null || echo \"\")\n",
+        "\n",
+        "if [ -n \"${HF_TOKEN:-}\" ]; then\n",
+        "  echo \"Logging in with HF_TOKEN...\"\n",
+        "  if [ -n \"$HF_BIN\" ]; then\n",
+        "    \"$HF_BIN\" login --token \"$HF_TOKEN\" --add-to-git-credential 2>/dev/null || true\n",
+        "  fi\n",
+        "  echo \"HF_TOKEN: set\"\n",
+        "else\n",
+        "  echo \"HF_TOKEN not set — checking for existing login session...\"\n",
+        "  if [ -n \"$HF_BIN\" ] && \"$HF_BIN\" whoami >/dev/null 2>&1; then\n",
+        "    echo \"Already logged in as: $(\\\"$HF_BIN\\\" whoami 2>/dev/null | head -1)\"\n",
+        "  else\n",
+        "    echo \"WARNING: No HF_TOKEN and no active login session.\"\n",
+        "    echo \"Inference will fail when downloading weights. Fix by either:\"\n",
+        "    echo \"  1. Setting HF_TOKEN in §2 and re-running from the top, or\"\n",
+        "    echo \"  2. Running: uvx hf@latest auth login\"\n",
+        "  fi\n",
+        "fi\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "transfer-hf-auth-code"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Verify GPU Environment\n"
+      ],
+      "id": "transfer-verify-md"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:46.485927Z",
+          "iopub.status.busy": "2026-06-09T04:27:46.485785Z",
+          "iopub.status.idle": "2026-06-09T04:27:51.151660Z",
+          "shell.execute_reply": "2026-06-09T04:27:51.151279Z"
+        }
+      },
+      "source": [
+        "import subprocess\n",
+        "\n",
+        "verify_code = r'''\n",
+        "import sys\n",
+        "import torch\n",
+        "print(\"uv group (env):\", __import__(\"os\").environ.get(\"COSMOS3_UV_GROUP\", \"?\"))\n",
+        "print(\"torch:\", torch.__version__)\n",
+        "print(\"torch cuda:\", torch.version.cuda)\n",
+        "print(\"cuda available:\", torch.cuda.is_available())\n",
+        "print(\"device count:\", torch.cuda.device_count())\n",
+        "if torch.cuda.is_available():\n",
+        "    print(\"device 0:\", torch.cuda.get_device_name(0))\n",
+        "else:\n",
+        "    print(\"FIX: set COSMOS3_UV_GROUP in §2 (cu130-train or cu128-train), re-run §6 install, then this cell.\")\n",
+        "    sys.exit(1)\n",
+        "'''\n",
+        "result = subprocess.run(\n",
+        "    [str(COSMOS3_REPO / \".venv\" / \"bin\" / \"python\"), \"-c\", verify_code],\n",
+        "    cwd=str(COSMOS3_REPO),\n",
+        "    env=os.environ.copy(),\n",
+        ")\n",
+        "if result.returncode != 0:\n",
+        "    raise RuntimeError(\n",
+        "        \"CUDA not available. Pass §3 first, then re-run §6 install with the correct COSMOS3_UV_GROUP.\"\n",
+        "    )\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "transfer-verify-code"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 8. Input Specs and Preview Helpers\n",
+        "\n",
+        "Checked-in [`specs/<control>.json`](./specs) are model-agnostic — the same spec runs with Nano and Super.\n",
+        "\n",
+        "Inference writes videos to:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/<model>/transfer_<control>/vision.mp4\n",
+        "```\n",
+        "\n",
+        "For example:\n",
+        "\n",
+        "```text\n",
+        "outputs/notebooks/Cosmos3-Nano/transfer_edge/vision.mp4\n",
+        "outputs/notebooks/Cosmos3-Super/transfer_edge/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "transfer-specs-md"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:51.153249Z",
+          "iopub.status.busy": "2026-06-09T04:27:51.153124Z",
+          "iopub.status.idle": "2026-06-09T04:27:51.160859Z",
+          "shell.execute_reply": "2026-06-09T04:27:51.160553Z"
+        }
+      },
+      "source": [
+        "missing = [c for c in TRANSFER_CONTROLS if not (COSMOS3_SPECS_DIR / f\"{c}.json\").is_file()]\n",
+        "if missing:\n",
+        "    raise FileNotFoundError(f\"missing checked-in specs for {missing} under {COSMOS3_SPECS_DIR}\")\n",
+        "print(\"Using specs:\", \", \".join(f\"{c}.json\" for c in TRANSFER_CONTROLS))\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "transfer-specs-code"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "execution": {
+          "iopub.execute_input": "2026-06-09T04:27:51.161868Z",
+          "iopub.status.busy": "2026-06-09T04:27:51.161754Z",
+          "iopub.status.idle": "2026-06-09T04:27:51.180588Z",
+          "shell.execute_reply": "2026-06-09T04:27:51.180287Z"
+        }
+      },
+      "source": [
+        "from preview_helpers import load_transfer_spec, resolve_spec_path\n",
+        "\n",
+        "for control in TRANSFER_CONTROLS:\n",
+        "    spec = load_transfer_spec(control)\n",
+        "    block = spec[control]\n",
+        "    print(\n",
+        "        f\"{control}: frames={spec.get('num_frames')} fps={spec.get('fps')} \"\n",
+        "        f\"guidance={spec.get('guidance')} control_guidance={spec.get('control_guidance')} \"\n",
+        "        f\"control={resolve_spec_path(block['control_path'])}\"\n",
+        "    )\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "transfer-spec-summary"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Nano Inference\n",
+        "\n",
+        "Run cells §9–§13 for **Cosmos3-Nano** (single GPU, `latency` preset). Outputs go to `<output_root>/Cosmos3-Nano/transfer_<control>/vision.mp4`.\n"
+      ],
+      "id": "edb56a21"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 9. Nano: Edge (Canny) Transfer\n",
+        "\n",
+        "Precomputed edge control (`control_edge.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_edge/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "b9622547"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=edge\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Nano \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "2d915ea4"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Edge (Canny) (Nano)\n"
+      ],
+      "id": "7a6de17b"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"edge\", model=\"Cosmos3-Nano\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "8290d2ca"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 10. Nano: Blur Transfer\n",
+        "\n",
+        "Blurred-reference control (`control_blur.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_blur/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "98da5fdc"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=blur\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Nano \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "000a6336"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Blur (Nano)\n"
+      ],
+      "id": "dc9aa146"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"blur\", model=\"Cosmos3-Nano\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "95cc1806"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 11. Nano: Depth Transfer\n",
+        "\n",
+        "Depth map control (`control_depth.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_depth/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "f1c66c3f"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=depth\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Nano \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "d2fc7fdd"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Depth (Nano)\n"
+      ],
+      "id": "25fb8a78"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"depth\", model=\"Cosmos3-Nano\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "08e8a6eb"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 12. Nano: Segmentation Transfer\n",
+        "\n",
+        "Segmentation map control (`control_seg.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_seg/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "2fc62770"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=seg\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Nano \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "a1185f0c"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Segmentation (Nano)\n"
+      ],
+      "id": "dbdf451b"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"seg\", model=\"Cosmos3-Nano\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "4f17565f"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 13. Nano: WSM Transfer\n",
+        "\n",
+        "World-scenario map control (`control_wsm.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_wsm/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "866eeb89"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=wsm\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Nano \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "cee87933"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview WSM (Nano)\n"
+      ],
+      "id": "7a320616"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"wsm\", model=\"Cosmos3-Nano\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "c126ae1a"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Super Inference\n",
+        "\n",
+        "Run cells §14–§18 for **Cosmos3-Super** (multi-GPU, 32B, `latency` preset). Requires `COSMOS3_NUM_GPUS` GPUs (auto-detected). Outputs go to `<output_root>/Cosmos3-Super/transfer_<control>/vision.mp4`.\n",
+        ""
+      ],
+      "id": "2d4226f3"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 14. Super: Edge (Canny) Transfer\n",
+        "\n",
+        "Precomputed edge control (`control_edge.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_edge/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "d0b5887b"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=edge\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/torchrun \\\n",
+        "  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n",
+        "  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n",
+        "  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n",
+        "  -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Super \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "4c7cf243"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Edge (Canny) (Super)\n"
+      ],
+      "id": "65054cf3"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"edge\", model=\"Cosmos3-Super\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "cc85a424"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 15. Super: Blur Transfer\n",
+        "\n",
+        "Blurred-reference control (`control_blur.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_blur/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "880ada8f"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=blur\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/torchrun \\\n",
+        "  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n",
+        "  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n",
+        "  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n",
+        "  -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Super \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "3e286ace"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Blur (Super)\n"
+      ],
+      "id": "9c9cf646"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"blur\", model=\"Cosmos3-Super\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "06dba23b"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 16. Super: Depth Transfer\n",
+        "\n",
+        "Depth map control (`control_depth.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_depth/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "f8425e18"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=depth\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/torchrun \\\n",
+        "  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n",
+        "  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n",
+        "  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n",
+        "  -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Super \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "6304cb3e"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Depth (Super)\n"
+      ],
+      "id": "d4e302af"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"depth\", model=\"Cosmos3-Super\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "0382d72f"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 17. Super: Segmentation Transfer\n",
+        "\n",
+        "Segmentation map control (`control_seg.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_seg/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "0e14ec79"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=seg\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/torchrun \\\n",
+        "  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n",
+        "  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n",
+        "  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n",
+        "  -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Super \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "d0f6bb46"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview Segmentation (Super)\n"
+      ],
+      "id": "662e2bf6"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"seg\", model=\"Cosmos3-Super\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "825845a5"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 18. Super: WSM Transfer\n",
+        "\n",
+        "World-scenario map control (`control_wsm.mp4`) + caption. Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_wsm/vision.mp4\n",
+        "```\n"
+      ],
+      "id": "6f09421d"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "CONTROL=wsm\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/torchrun \\\n",
+        "  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n",
+        "  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n",
+        "  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n",
+        "  -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Super \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "bba08873"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview WSM (Super)\n"
+      ],
+      "id": "db859493"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os\n",
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_transfer\n",
+        "\n",
+        "preview_transfer(\"wsm\", model=\"Cosmos3-Super\")\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "f392cf44"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 19. Multi-Control Transfer (Nano)\n",
+        "\n",
+        "Combines **edge** (Canny) and **blur** controls simultaneously from a single source video,\n",
+        "computed on-the-fly via `vision_path`. No pre-computed control files are needed.\n",
+        "\n",
+        "Spec: [`specs/multi_control.json`](./specs/multi_control.json).\n",
+        "Output:\n",
+        "\n",
+        "```text\n",
+        "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_multi_control/vision.mp4\n",
+        "```\n",
+        "\n",
+        "The framework also saves the intermediate control signals alongside the output:\n",
+        "`control_edge.mp4` and `control_blur.mp4`.\n"
+      ],
+      "id": "0e6dc02f"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "%%bash\n",
+        "set -euo pipefail\n",
+        "unset LD_LIBRARY_PATH\n",
+        "SPEC=\"$COSMOS3_TRANSFER_ROOT/specs/multi_control.json\"\n",
+        "OUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\n",
+        "mkdir -p \"$OUT_DIR\"\n",
+        "echo \"spec=$SPEC output=$OUT_DIR model=Cosmos3-Nano\"\n",
+        "cd \"$COSMOS3_REPO\"\n",
+        "CUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n",
+        ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+        "  --parallelism-preset=latency \\\n",
+        "  -i \"$SPEC\" \\\n",
+        "  -o \"$OUT_DIR\" \\\n",
+        "  --checkpoint-path Cosmos3-Nano \\\n",
+        "  --seed 2026\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7028c000"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Preview multi_control\n"
+      ],
+      "id": "1685cfc3"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import sys\n",
+        "from pathlib import Path\n",
+        "\n",
+        "_root = Path.cwd()\n",
+        "if not (_root / \"preview_helpers.py\").is_file():\n",
+        "    for p in [_root, *_root.parents]:\n",
+        "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
+        "        if (cand / \"preview_helpers.py\").is_file():\n",
+        "            _root = cand\n",
+        "            break\n",
+        "if str(_root) not in sys.path:\n",
+        "    sys.path.insert(0, str(_root))\n",
+        "\n",
+        "from preview_helpers import preview_multi_control\n",
+        "\n",
+        "preview_multi_control()\n"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "719dc385"
     }
-   },
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "import json\n",
-    "import os\n",
-    "import platform\n",
-    "import socket\n",
-    "\n",
-    "\n",
-    "def find_repo_root(start: Path) -> Path:\n",
-    "    for path in [start, *start.parents]:\n",
-    "        if (path / \"README.md\").exists() and (path / \"cookbooks\").exists():\n",
-    "            return path\n",
-    "    return start\n",
-    "\n",
-    "\n",
-    "def free_local_port() -> str:\n",
-    "    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:\n",
-    "        sock.bind((\"127.0.0.1\", 0))\n",
-    "        return str(sock.getsockname()[1])\n",
-    "\n",
-    "\n",
-    "def default_framework_repo(root: Path) -> Path:\n",
-    "    for candidate in (root / \"packages\" / \"cosmos-framework\", root / \"packages\" / \"cosmos3\"):\n",
-    "        if (candidate / \"pyproject.toml\").exists() and (candidate / \"cosmos_framework\").exists():\n",
-    "            return candidate\n",
-    "    return root / \"packages\" / \"cosmos3\"\n",
-    "\n",
-    "\n",
-    "COSMOS_ROOT = find_repo_root(Path.cwd().resolve())\n",
-    "COSMOS3_TRANSFER_ROOT = COSMOS_ROOT / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "COSMOS3_REPO = Path(os.environ.get(\"COSMOS3_REPO\", default_framework_repo(COSMOS_ROOT))).resolve()\n",
-    "COSMOS3_GIT_URL = os.environ.get(\n",
-    "    \"COSMOS3_GIT_URL\",\n",
-    "    \"https://github.com/NVIDIA/cosmos-framework.git\",\n",
-    ")\n",
-    "def default_uv_group() -> str:\n",
-    "    # cu128-train attention wheels are x86_64-only; aarch64 hosts need cu130-train for natten.\n",
-    "    if platform.machine() == \"aarch64\":\n",
-    "        return \"cu130-train\"\n",
-    "    return \"cu128-train\"\n",
-    "\n",
-    "\n",
-    "COSMOS3_UV_GROUP = os.environ.get(\"COSMOS3_UV_GROUP\", default_uv_group())\n",
-    "COSMOS3_TRANSFER_OUTPUT_ROOT = Path(\n",
-    "    os.environ.get(\n",
-    "        \"COSMOS3_TRANSFER_OUTPUT_ROOT\",\n",
-    "        COSMOS3_TRANSFER_ROOT / \"outputs\" / \"notebooks\",\n",
-    "    )\n",
-    ").resolve()\n",
-    "COSMOS3_SPECS_DIR = COSMOS3_TRANSFER_ROOT / \"specs\"\n",
-    "TRANSFER_CONTROLS = (\"edge\", \"blur\", \"depth\", \"seg\", \"wsm\")\n",
-    "\n",
-    "\n",
-    "def _detect_gpu_count() -> str:\n",
-    "    \"\"\"Count visible GPUs via nvidia-smi; fall back to 4.\"\"\"\n",
-    "    import subprocess\n",
-    "    try:\n",
-    "        out = subprocess.check_output(\n",
-    "            [\"nvidia-smi\", \"--query-gpu=name\", \"--format=csv,noheader\"],\n",
-    "            timeout=10, stderr=subprocess.DEVNULL,\n",
-    "        ).decode()\n",
-    "        count = len([l for l in out.strip().splitlines() if l])\n",
-    "        if count > 0:\n",
-    "            return str(count)\n",
-    "    except Exception:\n",
-    "        pass\n",
-    "    return \"4\"\n",
-    "\n",
-    "\n",
-    "COSMOS3_NUM_GPUS = os.environ.get(\"COSMOS3_NUM_GPUS\") or _detect_gpu_count()\n",
-    "\n",
-    "os.environ[\"COSMOS_ROOT\"] = str(COSMOS_ROOT)\n",
-    "os.environ[\"COSMOS3_TRANSFER_ROOT\"] = str(COSMOS3_TRANSFER_ROOT)\n",
-    "os.environ[\"COSMOS3_REPO\"] = str(COSMOS3_REPO)\n",
-    "os.environ[\"COSMOS3_GIT_URL\"] = COSMOS3_GIT_URL\n",
-    "os.environ[\"COSMOS3_UV_GROUP\"] = COSMOS3_UV_GROUP\n",
-    "os.environ[\"COSMOS3_TRANSFER_OUTPUT_ROOT\"] = str(COSMOS3_TRANSFER_OUTPUT_ROOT)\n",
-    "os.environ[\"COSMOS3_NUM_GPUS\"] = COSMOS3_NUM_GPUS\n",
-    "\n",
-    "\n",
-    "def default_cache_path(name: str) -> str:\n",
-    "    root = os.environ.get(\"COSMOS3_CACHE_ROOT\")\n",
-    "    if root:\n",
-    "        return str((Path(root).expanduser() / name).resolve())\n",
-    "    return str((COSMOS3_TRANSFER_ROOT / \".cache\" / name).resolve())\n",
-    "\n",
-    "\n",
-    "os.environ[\"UV_CACHE_DIR\"] = os.environ.get(\"COSMOS3_UV_CACHE_DIR\", default_cache_path(\"uv\"))\n",
-    "os.environ[\"HF_HOME\"] = os.environ.get(\"COSMOS3_HF_HOME\", default_cache_path(\"huggingface\"))\n",
-    "# NGC PyTorch images: clear bundled libtorch from LD_LIBRARY_PATH before inference.\n",
-    "os.environ.pop(\"LD_LIBRARY_PATH\", None)\n",
-    "# Default CUDA_VISIBLE_DEVICES to all detected GPUs so both Nano and Super cells work.\n",
-    "_all_gpus = \",\".join(str(i) for i in range(int(COSMOS3_NUM_GPUS)))\n",
-    "os.environ.setdefault(\"CUDA_VISIBLE_DEVICES\", _all_gpus)\n",
-    "os.environ.setdefault(\"COSMOS3_MASTER_ADDR\", \"127.0.0.1\")\n",
-    "os.environ.setdefault(\"COSMOS3_MASTER_PORT\", free_local_port())\n",
-    "\n",
-    "print(\"cosmos root:\", COSMOS_ROOT)\n",
-    "print(\"transfer cookbook:\", COSMOS3_TRANSFER_ROOT)\n",
-    "print(\"framework:\", COSMOS3_REPO)\n",
-    "print(\"controls:\", \", \".join(TRANSFER_CONTROLS))\n",
-    "print(\"output root:\", COSMOS3_TRANSFER_OUTPUT_ROOT)\n",
-    "print(\"UV_CACHE_DIR:\", os.environ[\"UV_CACHE_DIR\"])\n",
-    "print(\"HF_HOME:\", os.environ[\"HF_HOME\"])\n",
-    "print(\"COSMOS3_UV_GROUP:\", os.environ[\"COSMOS3_UV_GROUP\"])\n",
-    "print(\"COSMOS3_NUM_GPUS:\", os.environ[\"COSMOS3_NUM_GPUS\"])\n",
-    "print(\"CUDA_VISIBLE_DEVICES:\", os.environ[\"CUDA_VISIBLE_DEVICES\"])\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7e649ded",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:32.324823Z",
-     "iopub.status.busy": "2026-06-09T04:27:32.324648Z",
-     "iopub.status.idle": "2026-06-09T04:27:32.577517Z",
-     "shell.execute_reply": "2026-06-09T04:27:32.577151Z"
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
     }
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "echo \"hostname: $(hostname)\"\n",
-    "echo \"CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-<unset>}\"\n",
-    "if ! command -v nvidia-smi >/dev/null 2>&1; then\n",
-    "  echo \"ERROR: nvidia-smi not found. Run on a GPU host (see §1).\"\n",
-    "  exit 1\n",
-    "fi\n",
-    "nvidia-smi -L\n",
-    "GPU_COUNT=$(nvidia-smi -L 2>/dev/null | wc -l)\n",
-    "if [ \"${GPU_COUNT:-0}\" -lt 1 ]; then\n",
-    "  echo \"ERROR: no GPUs visible. Allocate a GPU or set CUDA_VISIBLE_DEVICES.\"\n",
-    "  exit 1\n",
-    "fi\n",
-    "echo \"OK: ${GPU_COUNT} GPU(s) visible on $(hostname)\""
-   ]
   },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-system-md",
-   "metadata": {},
-   "source": [
-    "## 4. Install system packages (Linux)\n",
-    "\n",
-    "Framework guardrails and previews need **ffmpeg**, **git-lfs**, and graphics libraries (`libxcb1`, `libgl1`, …). On hosts with `apt-get` (NGC PyTorch container, many training images), run the next cell to install them.\n",
-    "\n",
-    "If `apt-get` is unavailable, install the same packages with your OS package manager — see [Cosmos3 cookbooks README — System packages](../../README.md#system-packages-required-for-framework-guardrails).\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "320ddc9d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:32.578847Z",
-     "iopub.status.busy": "2026-06-09T04:27:32.578702Z",
-     "iopub.status.idle": "2026-06-09T04:27:36.082056Z",
-     "shell.execute_reply": "2026-06-09T04:27:36.081698Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "PACKAGES=(curl ffmpeg git-lfs libgl1 libglib2.0-0 libx11-dev libxcb1 tree wget)\n",
-    "\n",
-    "if command -v apt-get >/dev/null 2>&1; then\n",
-    "  export DEBIAN_FRONTEND=noninteractive\n",
-    "  echo \"Installing system packages via apt-get...\"\n",
-    "  apt-get update -qq\n",
-    "  apt-get install -y --no-install-recommends \"${PACKAGES[@]}\"\n",
-    "  echo \"OK: apt packages installed\"\n",
-    "else\n",
-    "  echo \"NOTE: apt-get not found on this host.\"\n",
-    "  echo \"If guardrails or OpenCV fail with libxcb.so.1, install manually:\"\n",
-    "  echo \"  ${PACKAGES[*]}\"\n",
-    "  echo \"See cookbooks/cosmos3/README.md (Framework guardrails).\"\n",
-    "fi\n",
-    "\n",
-    "for cmd in git ffmpeg; do\n",
-    "  command -v \"$cmd\" >/dev/null || { echo \"ERROR: missing $cmd\"; exit 1; }\n",
-    "done\n",
-    "if command -v git-lfs >/dev/null 2>&1; then\n",
-    "  git lfs install --skip-repo 2>/dev/null || true\n",
-    "  echo \"git-lfs: OK\"\n",
-    "else\n",
-    "  echo \"WARN: git-lfs not in PATH (uv sync may still work with GIT_LFS_SKIP_SMUDGE=1)\"\n",
-    "fi\n",
-    "echo \"System package check complete.\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5f79a744",
-   "metadata": {},
-   "source": [
-    "## 5. Clone Cosmos Framework\n",
-    "\n",
-    "Clones `COSMOS3_GIT_URL` into `COSMOS3_REPO` when the tree is not already present."
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "transfer-clone-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:36.083352Z",
-     "iopub.status.busy": "2026-06-09T04:27:36.083225Z",
-     "iopub.status.idle": "2026-06-09T04:27:36.789163Z",
-     "shell.execute_reply": "2026-06-09T04:27:36.788823Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "mkdir -p \"$(dirname \"$COSMOS3_REPO\")\"\n",
-    "\n",
-    "if [ -d \"$COSMOS3_REPO/.git\" ]; then\n",
-    "  echo \"Using existing framework checkout: $COSMOS3_REPO\"\n",
-    "elif [ -f \"$COSMOS3_REPO/pyproject.toml\" ] && [ -d \"$COSMOS3_REPO/cosmos_framework\" ]; then\n",
-    "  echo \"Using existing framework tree (no .git): $COSMOS3_REPO\"\n",
-    "else\n",
-    "  echo \"Cloning $COSMOS3_GIT_URL into $COSMOS3_REPO\"\n",
-    "  git clone \"$COSMOS3_GIT_URL\" \"$COSMOS3_REPO\"\n",
-    "fi\n",
-    "\n",
-    "cd \"$COSMOS3_REPO\"\n",
-    "if [ -d .git ]; then\n",
-    "  git status --short --branch\n",
-    "  git remote -v\n",
-    "fi\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-install-md",
-   "metadata": {},
-   "source": [
-    "## 6. Install Cosmos Framework Dependencies\n",
-    "\n",
-    "Installs [`uv`](https://docs.astral.sh/uv/) if missing, then runs `uv sync` to create `packages/cosmos3/.venv`. Uses `COSMOS3_UV_GROUP` from §2.\n",
-    "\n",
-    "**Skip:** if `.venv` already imports `cosmos_framework` with CUDA available, the next cell skips `uv sync` (fast re-runs). Set `COSMOS3_FORCE_UV_SYNC=1` to force a full re-sync.\n",
-    "\n",
-    "For `jupyter execute` on a GPU node, set `COSMOS3_UV_CACHE_DIR` / `COSMOS3_HF_HOME` (or `COSMOS3_CACHE_ROOT`) in §2 first.\n",
-    "\n",
-    "If you change `COSMOS3_UV_GROUP`, **re-run this cell** before inference.\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "transfer-install-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:36.790397Z",
-     "iopub.status.busy": "2026-06-09T04:27:36.790279Z",
-     "iopub.status.idle": "2026-06-09T04:27:46.484277Z",
-     "shell.execute_reply": "2026-06-09T04:27:46.483864Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "unset LD_LIBRARY_PATH\n",
-    "\n",
-    "if ! command -v uv >/dev/null 2>&1; then\n",
-    "  echo \"Installing uv...\"\n",
-    "  curl -LsSf https://astral.sh/uv/install.sh | sh\n",
-    "  # shellcheck disable=SC1091\n",
-    "  source \"${HOME}/.local/bin/env\" 2>/dev/null || export PATH=\"${HOME}/.local/bin:${PATH}\"\n",
-    "fi\n",
-    "uv self update 2>/dev/null || true\n",
-    "uv --version\n",
-    "\n",
-    "export GIT_LFS_SKIP_SMUDGE=1\n",
-    "mkdir -p \"$UV_CACHE_DIR\" \"$HF_HOME\"\n",
-    "cd \"$COSMOS3_REPO\"\n",
-    "export UV_CACHE_DIR=\"${UV_CACHE_DIR:?set paths in §2 (run the configure cell first)}\"\n",
-    "export UV_PROJECT_ENVIRONMENT=\"${UV_PROJECT_ENVIRONMENT:-$COSMOS3_REPO/.venv}\"\n",
-    "export UV_HTTP_TIMEOUT=\"${UV_HTTP_TIMEOUT:-600}\"\n",
-    "echo \"UV_CACHE_DIR=$UV_CACHE_DIR\"\n",
-    "echo \"COSMOS3_UV_GROUP=$COSMOS3_UV_GROUP\"\n",
-    "echo \"UV_HTTP_TIMEOUT=$UV_HTTP_TIMEOUT\"\n",
-    "\n",
-    "if [ -z \"${COSMOS3_FORCE_UV_SYNC:-}\" ] && [ -x \".venv/bin/python\" ]; then\n",
-    "  if env -u LD_LIBRARY_PATH .venv/bin/python -c \\\n",
-    "      'import cosmos_framework, torch; assert torch.cuda.is_available()'; then\n",
-    "    echo \"venv ready at $COSMOS3_REPO/.venv — skipping uv sync (set COSMOS3_FORCE_UV_SYNC=1 to re-sync)\"\n",
-    "    uv pip install imageio imageio-ffmpeg\n",
-    "    env -u LD_LIBRARY_PATH .venv/bin/python -c \\\n",
-    "      'import cosmos_framework, torch; print(\"venv OK (skipped sync)\")'\n",
-    "    exit 0\n",
-    "  fi\n",
-    "  echo \"Existing .venv failed CUDA/framework check — running full uv sync...\"\n",
-    "fi\n",
-    "\n",
-    "attempt=1\n",
-    "max_attempts=3\n",
-    "until uv sync --all-extras --group=\"$COSMOS3_UV_GROUP\"; do\n",
-    "  if [ \"$attempt\" -ge \"$max_attempts\" ]; then\n",
-    "    echo \"ERROR: uv sync failed after $max_attempts attempts (PyPI timeout or network).\"\n",
-    "    exit 1\n",
-    "  fi\n",
-    "  echo \"uv sync attempt $attempt failed; retrying in 30s...\"\n",
-    "  attempt=$((attempt + 1))\n",
-    "  sleep 30\n",
-    "done\n",
-    "\n",
-    "uv pip install imageio imageio-ffmpeg\n",
-    "\n",
-    "env -u LD_LIBRARY_PATH .venv/bin/python -c \\\n",
-    "  'import cosmos_framework, torch; assert torch.cuda.is_available(); print(\"venv OK\")'\n",
-    "echo \"Install complete: $COSMOS3_REPO/.venv\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-hf-auth-md",
-   "metadata": {},
-   "source": [
-    "## 6.5. Authenticate with Hugging Face\n",
-    "\n",
-    "Downloads Cosmos3 weights from Hugging Face during first inference. This cell uses `HF_TOKEN` from §2 if set, or falls back to an existing `hf login` session.\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "transfer-hf-auth-code",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "HF_BIN=\"$COSMOS3_REPO/.venv/bin/huggingface-cli\"\n",
-    "[ -x \"$HF_BIN\" ] || HF_BIN=$(command -v huggingface-cli 2>/dev/null || echo \"\")\n",
-    "\n",
-    "if [ -n \"${HF_TOKEN:-}\" ]; then\n",
-    "  echo \"Logging in with HF_TOKEN...\"\n",
-    "  if [ -n \"$HF_BIN\" ]; then\n",
-    "    \"$HF_BIN\" login --token \"$HF_TOKEN\" --add-to-git-credential 2>/dev/null || true\n",
-    "  fi\n",
-    "  echo \"HF_TOKEN: set\"\n",
-    "else\n",
-    "  echo \"HF_TOKEN not set — checking for existing login session...\"\n",
-    "  if [ -n \"$HF_BIN\" ] && \"$HF_BIN\" whoami >/dev/null 2>&1; then\n",
-    "    echo \"Already logged in as: $(\\\"$HF_BIN\\\" whoami 2>/dev/null | head -1)\"\n",
-    "  else\n",
-    "    echo \"WARNING: No HF_TOKEN and no active login session.\"\n",
-    "    echo \"Inference will fail when downloading weights. Fix by either:\"\n",
-    "    echo \"  1. Setting HF_TOKEN in §2 and re-running from the top, or\"\n",
-    "    echo \"  2. Running: uvx hf@latest auth login\"\n",
-    "  fi\n",
-    "fi\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-verify-md",
-   "metadata": {},
-   "source": [
-    "## 7. Verify GPU Environment\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "transfer-verify-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:46.485927Z",
-     "iopub.status.busy": "2026-06-09T04:27:46.485785Z",
-     "iopub.status.idle": "2026-06-09T04:27:51.151660Z",
-     "shell.execute_reply": "2026-06-09T04:27:51.151279Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import subprocess\n",
-    "\n",
-    "verify_code = r'''\n",
-    "import sys\n",
-    "import torch\n",
-    "print(\"uv group (env):\", __import__(\"os\").environ.get(\"COSMOS3_UV_GROUP\", \"?\"))\n",
-    "print(\"torch:\", torch.__version__)\n",
-    "print(\"torch cuda:\", torch.version.cuda)\n",
-    "print(\"cuda available:\", torch.cuda.is_available())\n",
-    "print(\"device count:\", torch.cuda.device_count())\n",
-    "if torch.cuda.is_available():\n",
-    "    print(\"device 0:\", torch.cuda.get_device_name(0))\n",
-    "else:\n",
-    "    print(\"FIX: set COSMOS3_UV_GROUP in §2 (cu130-train or cu128-train), re-run §6 install, then this cell.\")\n",
-    "    sys.exit(1)\n",
-    "'''\n",
-    "result = subprocess.run(\n",
-    "    [str(COSMOS3_REPO / \".venv\" / \"bin\" / \"python\"), \"-c\", verify_code],\n",
-    "    cwd=str(COSMOS3_REPO),\n",
-    "    env=os.environ.copy(),\n",
-    ")\n",
-    "if result.returncode != 0:\n",
-    "    raise RuntimeError(\n",
-    "        \"CUDA not available. Pass §3 first, then re-run §6 install with the correct COSMOS3_UV_GROUP.\"\n",
-    "    )\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "transfer-specs-md",
-   "metadata": {},
-   "source": [
-    "## 8. Input Specs and Preview Helpers\n",
-    "\n",
-    "Checked-in [`specs/<control>.json`](./specs) are model-agnostic — the same spec runs with Nano and Super.\n",
-    "\n",
-    "Inference writes videos to:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/<model>/transfer_<control>/vision.mp4\n",
-    "```\n",
-    "\n",
-    "For example:\n",
-    "\n",
-    "```text\n",
-    "outputs/notebooks/Cosmos3-Nano/transfer_edge/vision.mp4\n",
-    "outputs/notebooks/Cosmos3-Super/transfer_edge/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "transfer-specs-code",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:51.153249Z",
-     "iopub.status.busy": "2026-06-09T04:27:51.153124Z",
-     "iopub.status.idle": "2026-06-09T04:27:51.160859Z",
-     "shell.execute_reply": "2026-06-09T04:27:51.160553Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "missing = [c for c in TRANSFER_CONTROLS if not (COSMOS3_SPECS_DIR / f\"{c}.json\").is_file()]\n",
-    "if missing:\n",
-    "    raise FileNotFoundError(f\"missing checked-in specs for {missing} under {COSMOS3_SPECS_DIR}\")\n",
-    "print(\"Using specs:\", \", \".join(f\"{c}.json\" for c in TRANSFER_CONTROLS))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "transfer-spec-summary",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-06-09T04:27:51.161868Z",
-     "iopub.status.busy": "2026-06-09T04:27:51.161754Z",
-     "iopub.status.idle": "2026-06-09T04:27:51.180588Z",
-     "shell.execute_reply": "2026-06-09T04:27:51.180287Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from preview_helpers import load_transfer_spec, resolve_spec_path\n",
-    "\n",
-    "for control in TRANSFER_CONTROLS:\n",
-    "    spec = load_transfer_spec(control)\n",
-    "    block = spec[control]\n",
-    "    print(\n",
-    "        f\"{control}: frames={spec.get('num_frames')} fps={spec.get('fps')} \"\n",
-    "        f\"guidance={spec.get('guidance')} control_guidance={spec.get('control_guidance')} \"\n",
-    "        f\"control={resolve_spec_path(block['control_path'])}\"\n",
-    "    )\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edb56a21",
-   "metadata": {},
-   "source": [
-    "## Nano Inference\n",
-    "\n",
-    "Run cells §9–§13 for **Cosmos3-Nano** (single GPU, `latency` preset). Outputs go to `<output_root>/Cosmos3-Nano/transfer_<control>/vision.mp4`.\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b9622547",
-   "metadata": {},
-   "source": [
-    "## 9. Nano: Edge (Canny) Transfer\n",
-    "\n",
-    "Precomputed edge control (`control_edge.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_edge/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2d915ea4",
-   "metadata": {},
-   "outputs": [],
-   "source": "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=edge\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/python -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Nano \\\n  --seed 2026\n"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7a6de17b",
-   "metadata": {},
-   "source": [
-    "### Preview Edge (Canny) (Nano)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8290d2ca",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"edge\", model=\"Cosmos3-Nano\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98da5fdc",
-   "metadata": {},
-   "source": [
-    "## 10. Nano: Blur Transfer\n",
-    "\n",
-    "Blurred-reference control (`control_blur.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_blur/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "000a6336",
-   "metadata": {},
-   "outputs": [],
-   "source": "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=blur\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/python -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Nano \\\n  --seed 2026\n"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dc9aa146",
-   "metadata": {},
-   "source": [
-    "### Preview Blur (Nano)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "95cc1806",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"blur\", model=\"Cosmos3-Nano\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f1c66c3f",
-   "metadata": {},
-   "source": [
-    "## 11. Nano: Depth Transfer\n",
-    "\n",
-    "Depth map control (`control_depth.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_depth/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d2fc7fdd",
-   "metadata": {},
-   "outputs": [],
-   "source": "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=depth\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/python -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Nano \\\n  --seed 2026\n"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "25fb8a78",
-   "metadata": {},
-   "source": [
-    "### Preview Depth (Nano)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "08e8a6eb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"depth\", model=\"Cosmos3-Nano\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2fc62770",
-   "metadata": {},
-   "source": [
-    "## 12. Nano: Segmentation Transfer\n",
-    "\n",
-    "Segmentation map control (`control_seg.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_seg/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a1185f0c",
-   "metadata": {},
-   "outputs": [],
-   "source": "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=seg\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/python -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Nano \\\n  --seed 2026\n"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "dbdf451b",
-   "metadata": {},
-   "source": [
-    "### Preview Segmentation (Nano)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4f17565f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"seg\", model=\"Cosmos3-Nano\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "866eeb89",
-   "metadata": {},
-   "source": [
-    "## 13. Nano: WSM Transfer\n",
-    "\n",
-    "World-scenario map control (`control_wsm.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Nano/transfer_wsm/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cee87933",
-   "metadata": {},
-   "outputs": [],
-   "source": "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=wsm\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Nano\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Nano spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/python -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Nano \\\n  --seed 2026\n"
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7a320616",
-   "metadata": {},
-   "source": [
-    "### Preview WSM (Nano)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c126ae1a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"wsm\", model=\"Cosmos3-Nano\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2d4226f3",
-   "metadata": {},
-   "source": [
-    "## Super Inference\n",
-    "\n",
-    "Run cells §14–§18 for **Cosmos3-Super** (multi-GPU, 32B, `throughput` preset). Requires `COSMOS3_NUM_GPUS` GPUs (auto-detected). Outputs go to `<output_root>/Cosmos3-Super/transfer_<control>/vision.mp4`.\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d0b5887b",
-   "metadata": {},
-   "source": [
-    "## 14. Super: Edge (Canny) Transfer\n",
-    "\n",
-    "Precomputed edge control (`control_edge.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_edge/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4c7cf243",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=edge\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/torchrun \\\n  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n  -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Super \\\n  --seed 2026\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "65054cf3",
-   "metadata": {},
-   "source": [
-    "### Preview Edge (Canny) (Super)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cc85a424",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"edge\", model=\"Cosmos3-Super\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "880ada8f",
-   "metadata": {},
-   "source": [
-    "## 15. Super: Blur Transfer\n",
-    "\n",
-    "Blurred-reference control (`control_blur.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_blur/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3e286ace",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=blur\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/torchrun \\\n  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n  -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Super \\\n  --seed 2026\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9c9cf646",
-   "metadata": {},
-   "source": [
-    "### Preview Blur (Super)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "06dba23b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"blur\", model=\"Cosmos3-Super\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f8425e18",
-   "metadata": {},
-   "source": [
-    "## 16. Super: Depth Transfer\n",
-    "\n",
-    "Depth map control (`control_depth.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_depth/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6304cb3e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=depth\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/torchrun \\\n  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n  -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Super \\\n  --seed 2026\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d4e302af",
-   "metadata": {},
-   "source": [
-    "### Preview Depth (Super)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0382d72f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"depth\", model=\"Cosmos3-Super\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0e14ec79",
-   "metadata": {},
-   "source": [
-    "## 17. Super: Segmentation Transfer\n",
-    "\n",
-    "Segmentation map control (`control_seg.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_seg/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d0f6bb46",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=seg\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/torchrun \\\n  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n  -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Super \\\n  --seed 2026\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "662e2bf6",
-   "metadata": {},
-   "source": [
-    "### Preview Segmentation (Super)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "825845a5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"seg\", model=\"Cosmos3-Super\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6f09421d",
-   "metadata": {},
-   "source": [
-    "## 18. Super: WSM Transfer\n",
-    "\n",
-    "World-scenario map control (`control_wsm.mp4`) + caption. Output:\n",
-    "\n",
-    "```text\n",
-    "<COSMOS3_TRANSFER_OUTPUT_ROOT>/Cosmos3-Super/transfer_wsm/vision.mp4\n",
-    "```\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bba08873",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%bash\nset -euo pipefail\nunset LD_LIBRARY_PATH\nCONTROL=wsm\nSPEC=\"$COSMOS3_TRANSFER_ROOT/specs/${CONTROL}.json\"\nOUT_DIR=\"$COSMOS3_TRANSFER_OUTPUT_ROOT/Cosmos3-Super\"\nmkdir -p \"$OUT_DIR\"\necho \"control=$CONTROL model=Cosmos3-Super spec=$SPEC output=$OUT_DIR\"\ncd \"$COSMOS3_REPO\"\nCUDA_VISIBLE_DEVICES=\"${CUDA_VISIBLE_DEVICES}\" \\\n.venv/bin/torchrun \\\n  --nproc-per-node=\"${COSMOS3_NUM_GPUS}\" \\\n  --master-addr=\"${COSMOS3_MASTER_ADDR}\" \\\n  --master-port=\"${COSMOS3_MASTER_PORT}\" \\\n  -m cosmos_framework.scripts.inference \\\n  --parallelism-preset=latency \\\n  -i \"$SPEC\" \\\n  -o \"$OUT_DIR\" \\\n  --checkpoint-path Cosmos3-Super \\\n  --seed 2026\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "db859493",
-   "metadata": {},
-   "source": [
-    "### Preview WSM (Super)\n"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f392cf44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import sys\n",
-    "from pathlib import Path\n",
-    "\n",
-    "_root = Path.cwd()\n",
-    "if not (_root / \"preview_helpers.py\").is_file():\n",
-    "    for p in [_root, *_root.parents]:\n",
-    "        cand = p / \"cookbooks\" / \"cosmos3\" / \"generator\" / \"transfer\"\n",
-    "        if (cand / \"preview_helpers.py\").is_file():\n",
-    "            _root = cand\n",
-    "            break\n",
-    "if str(_root) not in sys.path:\n",
-    "    sys.path.insert(0, str(_root))\n",
-    "\n",
-    "from preview_helpers import preview_transfer\n",
-    "\n",
-    "preview_transfer(\"wsm\", model=\"Cosmos3-Super\")\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/cookbooks/cosmos3/generator/transfer/specs/blur.json
+++ b/cookbooks/cosmos3/generator/transfer/specs/blur.json
@@ -21,5 +21,6 @@
   "blur": {
     "control_path": "../assets/blur/control_blur.mp4",
     "preset_blur_strength": "medium"
-  }
+  },
+  "emphasize_control_in_prompt": false
 }

--- a/cookbooks/cosmos3/generator/transfer/specs/depth.json
+++ b/cookbooks/cosmos3/generator/transfer/specs/depth.json
@@ -20,5 +20,6 @@
   "prompt_path": "../assets/depth/prompt.json",
   "depth": {
     "control_path": "../assets/depth/control_depth.mp4"
-  }
+  },
+  "emphasize_control_in_prompt": false
 }

--- a/cookbooks/cosmos3/generator/transfer/specs/edge.json
+++ b/cookbooks/cosmos3/generator/transfer/specs/edge.json
@@ -21,5 +21,6 @@
   "edge": {
     "control_path": "../assets/edge/control_edge.mp4",
     "preset_edge_threshold": "medium"
-  }
+  },
+  "emphasize_control_in_prompt": false
 }

--- a/cookbooks/cosmos3/generator/transfer/specs/multi_control.json
+++ b/cookbooks/cosmos3/generator/transfer/specs/multi_control.json
@@ -1,11 +1,13 @@
 {
+  "name": "transfer_multi_control",
   "model_mode": "video2video",
   "resolution": "720",
+  "aspect_ratio": "16,9",
   "num_frames": 121,
   "fps": 30,
   "shift": 10.0,
   "num_steps": 50,
-  "seed": 2025,
+  "seed": 2026,
   "num_video_frames_per_chunk": 121,
   "num_conditional_frames": 1,
   "num_first_chunk_conditional_frames": 0,
@@ -14,7 +16,15 @@
   "negative_prompt_keep_metadata": false,
   "guidance": 3.0,
   "control_guidance": 1.5,
+  "negative_prompt_file": "../assets/negative_prompt.json",
+  "prompt_path": "../assets/multi_control/prompt.json",
+  "vision_path": "https://github.com/nvidia-cosmos/cosmos-dependencies/raw/2b17a2413bd86b2cf9b03823637108851e4ddf2d/inputs/vision/robot_pouring.mp4",
+  "edge": {
+    "weight": 0.5,
+    "preset_edge_threshold": "medium"
+  },
   "blur": {
+    "weight": 0.5,
     "preset_blur_strength": "medium"
   },
   "emphasize_control_in_prompt": false

--- a/cookbooks/cosmos3/generator/transfer/specs/seg.json
+++ b/cookbooks/cosmos3/generator/transfer/specs/seg.json
@@ -20,5 +20,6 @@
   "prompt_path": "../assets/seg/prompt.json",
   "seg": {
     "control_path": "../assets/seg/control_seg.mp4"
-  }
+  },
+  "emphasize_control_in_prompt": false
 }

--- a/cookbooks/cosmos3/generator/transfer/specs/wsm.json
+++ b/cookbooks/cosmos3/generator/transfer/specs/wsm.json
@@ -20,5 +20,6 @@
   "prompt_path": "../assets/wsm/prompt.json",
   "wsm": {
     "control_path": "../assets/wsm/control_wsm.mp4"
-  }
+  },
+  "emphasize_control_in_prompt": false
 }

--- a/evaluation/cosmos3/generator/paibench_c/README.md
+++ b/evaluation/cosmos3/generator/paibench_c/README.md
@@ -27,6 +27,9 @@ export HF_TOKEN=hf_...
 # Quick smoke-test: 4 tasks, edge modality, Cosmos3-Nano (default)
 bash run_paibench_c.sh
 
+# Quick smoke-test: 4 tasks, all 4 modalities, Cosmos3-Nano
+PAIBENCH_C_MODALITIES="edge blur depth seg" bash run_paibench_c.sh
+
 # Full 600-task run, Cosmos3-Nano (run once per modality)
 PAIBENCH_C_NUM_SAMPLES=600 PAIBENCH_C_CHECKPOINT=Cosmos3-Nano PAIBENCH_C_MODALITIES=edge  bash run_paibench_c.sh
 PAIBENCH_C_NUM_SAMPLES=600 PAIBENCH_C_CHECKPOINT=Cosmos3-Nano PAIBENCH_C_MODALITIES=blur  bash run_paibench_c.sh
@@ -56,7 +59,7 @@ with inline video previews and metric display.
 
 - `run_paibench_c.sh` — self-contained bash script; mirrors every step of the notebook.
 - `run_with_cosmos_framework.ipynb` — interactive notebook (demo case + four full-sweep cells).
-- `assets/prompts.json` — 600 task entries, each with:
+- `assets/tasks.json` — 600 task entries, each with:
   - `caption` — the actual generation prompt used in the internal evaluation run (fully upsampled JSON description).
   - `video_path`, `canny_path`, `blur_path`, `depth_path`, `seg_path` — relative paths within the HF dataset to the GT video and each control-signal video.
   - `negative_prompt` — shared negative prompt.
@@ -84,15 +87,19 @@ physical-ai-bench-conditional-generation/
 
 ## Sampling Settings
 
-| Setting          | edge | blur | depth | seg |
-| ---------------- | ---: | ---: | ----: | --: |
-| num_frames       |  121 |  121 |   121 | 121 |
-| fps              |   30 |   30 |    30 |  30 |
-| resolution       | 720p | 720p |  720p | 720p |
-| num_steps        |   50 |   50 |    50 |  50 |
-| guidance         |  3.0 |  3.0 |   3.0 | 3.0 |
-| control_guidance |  1.5 |  1.5 |   1.5 | 2.0 |
-| seed             | 2026 | 2026 |  2026 | 2026 |
+| Setting                    | edge | blur | depth | seg |
+| -------------------------- | ---: | ---: | ----: | --: |
+| num_frames                 |  121 |  121 |   121 | 121 |
+| fps                        |   30 |   30 |    30 |  30 |
+| resolution                 | 720p | 720p |  720p | 720p |
+| num_steps                  |   50 |   50 |    50 |  50 |
+| guidance                   |  3.0 |  3.0 |   3.0 | 3.0 |
+| control_guidance           |  1.5 |  1.5 |   1.5 | 2.0 |
+| seed                       | 2025 | 2025 |  2025 | 2025 |
+| emphasize_control_in_prompt | false | false | false | false |
+
+> `fps`, `aspect_ratio`, and `seed` in the spec are overridden per-task from `assets/tasks.json`.
+> `emphasize_control_in_prompt: false` disables the automatic control-hint suffix appended to the prompt.
 
 ## Reference Scores
 

--- a/evaluation/cosmos3/generator/paibench_c/run_paibench_c.sh
+++ b/evaluation/cosmos3/generator/paibench_c/run_paibench_c.sh
@@ -544,45 +544,140 @@ dst.write_text("\n".join(json.dumps(r) for r in rows))
 print(f"Wrote {len(rows)} rows → {dst}")
 PY
 
-    local _ntasks
-    _ntasks="$PAIBENCH_C_NUM_SAMPLES"
-    log "  Running inference: modality=$MODALITY  tasks=$_ntasks  gpus=$COSMOS3_NUM_GPUS ..."
-    pushd "$COSMOS3_REPO" >/dev/null
-    # Unset vars that can contaminate the cosmos3 Python workers when called from
+    # -------------------------------------------------------------------------
+    # Run inference using N parallel single-GPU workers — one per GPU.
+    # This matches the internal run_transferbench_oss_inference.sh exactly:
+    #   - Each worker owns one GPU (CUDA_VISIBLE_DEVICES=<id>)
+    #   - Each worker processes its interleaved task shard independently
+    #   - Tasks with valid existing outputs are skipped (resume-safe)
+    # Why this avoids GPU OOM: each worker handles only N/NGPU tasks (~150
+    # for 600 tasks total), so accumulated tensors never exhaust VRAM.
+    # With one shared multi-GPU torchrun (--parallelism-preset=latency), all
+    # 600 tasks run in a single process; unreleased diffusion intermediates
+    # accumulate after ~200 tasks and production of empty 7 KB stubs begins.
+    # -------------------------------------------------------------------------
+    local _min_valid_bytes=50000   # < 50 KB → empty/failed video stub
+
+    # Unset vars that can contaminate cosmos3 Python workers when called from
     # a Jupyter/notebook environment.
     unset PYTHONPATH PYTHONSTARTUP PYTHONHOME MPLBACKEND 2>/dev/null || true
     export TORCH_HOME="${TRITON_CACHE_DIR%/triton}"
-    CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" LD_LIBRARY_PATH= \
-    "$COSMOS3_UV_ENV/bin/torchrun" \
-        --standalone \
-        --nproc-per-node="$COSMOS3_NUM_GPUS" \
-        -m cosmos_framework.scripts.inference \
-        --parallelism-preset=latency \
-        -i "$INPUT_JSONL" \
-        -o "$RAW_DIR" \
-        --checkpoint-path "$PAIBENCH_C_CHECKPOINT" \
-        --no-guardrails
-    popd >/dev/null
+
+    # Parse GPU list from CUDA_VISIBLE_DEVICES (e.g. "0,1,2,3" → array).
+    IFS=',' read -ra _gpu_ids <<< "$CUDA_VISIBLE_DEVICES"
+    local _num_gpus="${#_gpu_ids[@]}"
+    local _py="${COSMOS3_UV_ENV}/bin/python"
+    [[ -x "$_py" ]] || _py="$(command -v python3 || command -v python)"
+
+    log "  Running inference: modality=$MODALITY  tasks=$PAIBENCH_C_NUM_SAMPLES  gpus=$_num_gpus (parallel single-GPU workers) ..."
+
+    # Build per-GPU shard JSONLs — interleaved distribution matches the
+    # internal script: GPU 0 → tasks 0,4,8,…; GPU 1 → tasks 1,5,9,… etc.
+    local -a _shard_jsonls=()
+    local gi
+    for (( gi=0; gi<_num_gpus; gi++ )); do
+        local _shard_jsonl="$OUTPUT_DIR/shard_${gi}.jsonl"
+        _shard_jsonls+=("$_shard_jsonl")
+        PAIBENCH_C_RAW_DIR="$RAW_DIR" \
+        PAIBENCH_C_INPUT_JSONL="$INPUT_JSONL" \
+        PAIBENCH_C_SHARD_JSONL="$_shard_jsonl" \
+        PAIBENCH_C_SHARD_IDX="$gi" \
+        PAIBENCH_C_NUM_SHARDS="$_num_gpus" \
+        PAIBENCH_C_MIN_VALID_BYTES="$_min_valid_bytes" \
+        "$_py" - <<'PY'
+import json, os, pathlib
+
+raw_dir     = pathlib.Path(os.environ["PAIBENCH_C_RAW_DIR"])
+input_jsonl = pathlib.Path(os.environ["PAIBENCH_C_INPUT_JSONL"])
+shard_jsonl = pathlib.Path(os.environ["PAIBENCH_C_SHARD_JSONL"])
+shard_idx   = int(os.environ["PAIBENCH_C_SHARD_IDX"])
+num_shards  = int(os.environ["PAIBENCH_C_NUM_SHARDS"])
+min_bytes   = int(os.environ["PAIBENCH_C_MIN_VALID_BYTES"])
+
+all_rows = [json.loads(l) for l in input_jsonl.read_text().strip().splitlines()]
+# Interleaved: GPU 0 gets rows 0,4,8,…; GPU 1 gets rows 1,5,9,… etc.
+shard_rows = [r for i, r in enumerate(all_rows) if i % num_shards == shard_idx]
+
+pending = []
+for row in shard_rows:
+    name = row["name"]
+    vision_mp4 = raw_dir / name / "vision.mp4"
+    if vision_mp4.exists() and vision_mp4.stat().st_size >= min_bytes:
+        continue  # already generated — skip
+    # Remove stale empty stub so the framework recreates the task dir cleanly.
+    if vision_mp4.exists():
+        vision_mp4.unlink()
+    pending.append(row)
+
+shard_jsonl.write_text("\n".join(json.dumps(r) for r in pending))
+skipped = len(shard_rows) - len(pending)
+print(f"Shard {shard_idx}/{num_shards}: {len(pending)} to generate, {skipped} already done")
+PY
+    done
+
+    # Launch one background Python process per GPU — no torch.distributed.
+    local -a _worker_pids=()
+    for (( gi=0; gi<_num_gpus; gi++ )); do
+        local _shard_jsonl="${_shard_jsonls[$gi]}"
+        local _pending_count
+        _pending_count="$(wc -l < "$_shard_jsonl" | tr -d ' ')"
+        local _gpu_id="${_gpu_ids[$gi]}"
+
+        if [[ "$_pending_count" -eq 0 ]]; then
+            log "  GPU $_gpu_id: all tasks done, skipping"
+            rm -f "$_shard_jsonl"
+            continue
+        fi
+
+        log "  GPU $_gpu_id: $_pending_count tasks (starting background worker) ..."
+        (
+            cd "$COSMOS3_REPO"
+            CUDA_VISIBLE_DEVICES="$_gpu_id" LD_LIBRARY_PATH= \
+            "$COSMOS3_UV_ENV/bin/python" \
+                -m cosmos_framework.scripts.inference \
+                --parallelism-preset=latency \
+                --no-guardrails \
+                -i "$_shard_jsonl" \
+                -o "$RAW_DIR" \
+                --checkpoint-path "$PAIBENCH_C_CHECKPOINT"
+            rm -f "$_shard_jsonl"
+        ) &
+        _worker_pids+=("$!")
+    done
+
+    # Wait for all GPU workers to finish.
+    local _fail=0
+    for _pid in "${_worker_pids[@]}"; do
+        wait "$_pid" || _fail=1
+    done
+    [[ "$_fail" -eq 0 ]] || die "One or more GPU workers failed for modality=$MODALITY"
 
     log "  Flattening outputs → $OUTPUT_DIR/videos/ ..."
-    # Flattening only uses stdlib - fall back to system python3 if the venv python
-    # symlink is broken (uv-managed Python not present on this node).
+    # Copy only valid (non-empty) vision.mp4 files.  Stale stub files from
+    # earlier failed runs are excluded by the min-size guard.
     _py="${COSMOS3_UV_ENV}/bin/python"
     [[ -x "$_py" ]] || _py="$(command -v python3 || command -v python)"
     PAIBENCH_C_RAW_DIR="$RAW_DIR" \
     PAIBENCH_C_VIDEOS_DIR="$OUTPUT_DIR/videos" \
+    PAIBENCH_C_MIN_VALID_BYTES="$_min_valid_bytes" \
     "$_py" - <<'PY'
 import os, shutil, pathlib
-raw  = pathlib.Path(os.environ["PAIBENCH_C_RAW_DIR"])
-vids = pathlib.Path(os.environ["PAIBENCH_C_VIDEOS_DIR"])
+raw      = pathlib.Path(os.environ["PAIBENCH_C_RAW_DIR"])
+vids     = pathlib.Path(os.environ["PAIBENCH_C_VIDEOS_DIR"])
+min_sz   = int(os.environ["PAIBENCH_C_MIN_VALID_BYTES"])
 vids.mkdir(parents=True, exist_ok=True)
-count = 0
+copied = skipped_exists = skipped_empty = 0
 for mp4 in sorted(raw.rglob("vision.mp4")):
     dst = vids / f"{mp4.parent.name}.mp4"
-    if not dst.exists():
-        shutil.copy2(mp4, dst)
-    count += 1
-print(f"Collected {count} video(s) → {vids}")
+    if dst.exists():
+        skipped_exists += 1
+        continue
+    if mp4.stat().st_size < min_sz:
+        skipped_empty += 1
+        continue
+    shutil.copy2(mp4, dst)
+    copied += 1
+print(f"Collected {copied} video(s) → {vids}  (skipped: {skipped_exists} existing, {skipped_empty} empty)")
 PY
     log "  Generation complete: $MODALITY"
 }

--- a/evaluation/cosmos3/generator/paibench_c/specs/depth.json
+++ b/evaluation/cosmos3/generator/paibench_c/specs/depth.json
@@ -14,5 +14,6 @@
   "negative_prompt_keep_metadata": false,
   "guidance": 3.0,
   "control_guidance": 1.5,
-  "depth": {}
+  "depth": {},
+  "emphasize_control_in_prompt": false
 }

--- a/evaluation/cosmos3/generator/paibench_c/specs/edge.json
+++ b/evaluation/cosmos3/generator/paibench_c/specs/edge.json
@@ -16,5 +16,6 @@
   "control_guidance": 1.5,
   "edge": {
     "preset_edge_threshold": "medium"
-  }
+  },
+  "emphasize_control_in_prompt": false
 }

--- a/evaluation/cosmos3/generator/paibench_c/specs/seg.json
+++ b/evaluation/cosmos3/generator/paibench_c/specs/seg.json
@@ -14,5 +14,6 @@
   "negative_prompt_keep_metadata": false,
   "guidance": 3.0,
   "control_guidance": 2.0,
-  "seg": {}
+  "seg": {},
+  "emphasize_control_in_prompt": false
 }


### PR DESCRIPTION
**Multi-control transfer**
- Add `specs/multi_control.json`: edge (weight=0.75) + blur (weight=0.25) computed on-the-fly from `vision_path`
- Add `assets/multi_control/prompt.json` with per-hint caption