### PR TITLE
docs: document --no-guardrails vLLM-Omni startup in cookbook setup

### DIFF
--- a/cookbooks/cosmos3/README.md
+++ b/cookbooks/cosmos3/README.md
@@ -280,6 +280,34 @@ Generator cookbooks.
 Cosmos3 checkpoints can exceed the default server init timeout — always pass
 `--init-timeout 1800` on every `vllm serve` command below.
 
+### Guardrails (gated dependency)
+
+The vLLM-Omni server loads gated
+[nvidia/Cosmos-1.0-Guardrail](https://huggingface.co/nvidia/Cosmos-1.0-Guardrail)
+at startup by default. Without Hugging Face access to that repo, the server
+exits before serving requests. Per-request `guardrails: false` in `extra_params`
+(see [Prerequisites](#prerequisites)) does not fix this — the guardrail models
+must load at startup.
+
+To disable guardrails server-wide (you are responsible for
+[license compliance](https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-license)),
+add `--no-guardrails` to any `vllm serve` command below:
+
+```bash
+vllm serve nvidia/Cosmos3-Nano \
+  --omni \
+  --model-class-name Cosmos3OmniDiffusersPipeline \
+  --no-guardrails \
+  --allowed-local-media-path / \
+  --port 8000 \
+  --init-timeout 1800
+```
+
+Alternatively, pass a
+[`--deploy-config`](../../README.md#generator-with-vllm-omni) as documented in
+the repository root README. See also the
+[vLLM-Omni Cosmos3-Nano recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/cosmos3/Cosmos3-Nano.md).
+
 ### Option 1: Docker (recommended)
 
 The prebuilt image `vllm/vllm-omni:cosmos3` supports every Generator modality


### PR DESCRIPTION
## Summary

Addresses #196.

Documents how to start the vLLM-Omni Generator server when the user lacks
access to gated `nvidia/Cosmos-1.0-Guardrail`. The shared cookbook setup
(`cookbooks/cosmos3/README.md`) previously showed only the default
`vllm serve` command; without Guardrail HF access, startup fails before
any request is served.

This PR adds a short **Guardrails (gated dependency)** section under
`## vLLM-Omni` that explains:

- Guardrails load at **server startup**, not per request
- Per-request `guardrails: false` in `extra_params` does **not** fix startup failures
- Add `--no-guardrails` to disable guardrails server-wide (primary path, per
  [vLLM-Omni Cosmos3-Nano recipe](https://github.com/vllm-project/vllm-omni/blob/main/recipes/cosmos3/Cosmos3-Nano.md))
- `--deploy-config` is mentioned as an alternative documented in the repo root README

Existing Docker and Native command blocks are unchanged; users add
`--no-guardrails` as needed.

## Test plan

- [x] Docs-only change; no code or config changes
- [x] Verified locally that `vllm serve nvidia/Cosmos3-Nano --omni \
  --model-class-name Cosmos3OmniDiffusersPipeline --no-guardrails \
  --allowed-local-media-path / --port 8008 --init-timeout 1800` starts
  without attempting to load gated guardrail models