### PR TITLE
Add VideoPhy-2 Reasoner SFT recipe for Cosmos3-Super

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookb
 | [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT for action policy on the DROID dataset | [`launch_sft_action_policy_droid.sh`](cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid.sh) |
 | [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Alignment SFT on LLaVA-OneVision | [`launch_sft_llava_ov.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh) |
 | [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Physical-plausibility SFT on VideoPhy-2 | [`launch_sft_videophy2_nano.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh) |
+| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Super | Physical-plausibility SFT on VideoPhy-2 | [`launch_sft_videophy2_super.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_super.sh) |
 
 These cookbooks run on the [Cosmos Framework](https://github.com/NVIDIA/cosmos-framework), NVIDIA's end-to-end Physical AI framework for training and serving world models. For the full post-training reference — every config field, raw `torchrun`, resuming, and advanced parallelism — see the [Cosmos Framework training guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/training.md).
 

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -6,8 +6,9 @@ Supervised fine-tuning (SFT) of the Cosmos3 Reasoner on your own data. Tested on
 | --- | --- | --- | --- |
 | Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; Cosmos3-Nano Reasoner checkpoint auto-prepared |
 | Physical-plausibility SFT (VideoPhy-2) | `launch_sft_videophy2_nano.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | 1–5 plausibility scoring; dataset + checkpoint auto-prepared |
+| Physical-plausibility SFT (VideoPhy-2, Cosmos3-Super) | `launch_sft_videophy2_super.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | Cosmos3-Super tier — Qwen3-VL-32B full fine-tune; dataset + checkpoint auto-prepared |
 
-Both use `[job].task = "vlm"` and bootstrap from a Cosmos3-Nano Reasoner checkpoint, auto-prepared on first run.
+All use `[job].task = "vlm"`. The Nano recipes bootstrap from a Cosmos3-Nano Reasoner checkpoint; the Cosmos3-Super recipe bootstraps from a Cosmos3-Super Reasoner checkpoint (Cosmos3-Super LM merged onto the Qwen3-VL-32B visual tower). Both checkpoints are auto-prepared on first run.
 
 ## Prerequisites
 
@@ -25,6 +26,8 @@ Each launcher is a complete recipe — just run it from this folder:
 bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, builds the Cosmos3-Nano Reasoner checkpoint, then trains
 # or
 bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the Cosmos3-Nano Reasoner checkpoint, then trains
+# or (Cosmos3-Super tier — Qwen3-VL-32B full fine-tune)
+bash launch_sft_videophy2_super.sh   # first run materializes VideoPhy-2 + builds the Cosmos3-Super Reasoner checkpoint, then trains
 ```
 
 The VideoPhy-2 download/convert steps are skipped once their outputs exist. Paths are fixed at the top of each script — edit them there to relocate data or checkpoints.

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_super.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_super.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# Complete recipe: Reasoner physical-plausibility SFT on VideoPhy-2, Cosmos3-Super
+# tier (Qwen3-VL-32B full fine-tune) (8x H100).
+# Run from this folder with the cosmos-framework venv active (see README):
+#   bash launch_sft_videophy2_super.sh
+# It materializes the dataset, builds the Cosmos3-Super Reasoner checkpoint, and
+# trains — in order. Paths are fixed under this folder.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Super-variant allocator tweak: expandable_segments so the 32B backbone fits
+# without OOM. (We do NOT clear LD_LIBRARY_PATH — VideoPhy-2 clips are decoded with
+# torchcodec, which dlopen()s the CUDA NPP + FFmpeg libs off LD_LIBRARY_PATH.)
+export PYTORCH_ALLOC_CONF="${PYTORCH_ALLOC_CONF:-expandable_segments:True}"
+
+VIDEOPHYSICS_ROOT="$PWD/data/videophysics"
+REASONER_CHECKPOINT="$PWD/checkpoints/Cosmos3-Super-Reasoner"
+
+# 1. Materialize the VideoPhy-2 dataset (skipped if present).
+if [[ ! -d "$VIDEOPHYSICS_ROOT/videophy2_train" ]]; then
+    python -m cosmos_framework.scripts.reasoner.prepare_videophy2_from_hf --out_root "$VIDEOPHYSICS_ROOT" --split both
+fi
+
+# 2. Build the Cosmos3-Super Reasoner checkpoint: merge the Cosmos3-Super LM onto
+#    the Qwen3-VL-32B visual tower (skipped if present).
+if [[ ! -d "$REASONER_CHECKPOINT" ]]; then
+    python -m cosmos_framework.scripts.convert_model_to_vlm_safetensors --checkpoint-path Cosmos3-Super --vlm-model-name Qwen/Qwen3-VL-32B-Instruct -o "$REASONER_CHECKPOINT"
+fi
+
+# 3. Train (8-GPU FSDP). VIDEOPHYSICS_ROOT is read from the environment; the
+#    checkpoint is supplied as a config override after `--`.
+export VIDEOPHYSICS_ROOT
+# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
+IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
+    -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/videophy2_sft_super.toml" \
+    -- model.config.policy.backbone.safetensors_path="$REASONER_CHECKPOINT"

--- a/cookbooks/cosmos3/reasoner/finetune/toml/sft_config/videophy2_sft_super.toml
+++ b/cookbooks/cosmos3/reasoner/finetune/toml/sft_config/videophy2_sft_super.toml
@@ -1,24 +1,33 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: OpenMDW-1.1
 
-# videophy2_sft_nano — VLM dialog SFT on VideoPhy-2 via CosmosDataLoader.
+# videophy2_sft_super — VLM dialog SFT on VideoPhy-2 via CosmosDataLoader,
+# Cosmos3-Super tier (Qwen3-VL-32B full fine-tune).
 # Base config = cosmos_framework/configs/base/reasoner/config.py (selected by [job].task="vlm").
+#
+# Super-tier counterpart of videophy2_sft_nano: same dataset + dataflow, but the
+# 32B backbone (Qwen/Qwen3-VL-32B-Instruct) and FSDP full-shard across every rank
+# (data_parallel_shard_degree=-1, auto from WORLD_SIZE) so it fits on a 4-GPU
+# (e.g. GB200x4) or 8-GPU allocation. Still a full fine-tune (no LoRA).
 #
 # Dataset prep:
 #   python -m cosmos_framework.scripts.reasoner.prepare_videophy2_from_hf \
 #       --out_root $VIDEOPHYSICS_ROOT --split train  # and again with --split val
 #
 # Required env at launch: VIDEOPHYSICS_ROOT (read by the experiment Python).
+# The launch script auto-builds the merged Cosmos3-Super Reasoner checkpoint
+# (checkpoints/Cosmos3-Super-Reasoner) on first run and passes it to the model
+# via the model.config.policy.backbone.safetensors_path override.
 #
-# Example launch:
-#   bash launch_sft_videophy2_nano.sh
+# Example launch (from cookbooks/cosmos3/reasoner/finetune/):
+#   bash launch_sft_videophy2_super.sh
 
 [job]
 task         = "vlm"
-experiment   = "videophy2_sft_nano"
+experiment   = "videophy2_sft_super"
 project      = "cosmos3"
 group        = "vlm_videophy2_sft"
-name         = "videophy2_sft_nano"
+name         = "videophy2_sft_super"
 wandb_mode   = "disabled"
 
 [model]
@@ -26,7 +35,7 @@ attn_implementation = "cosmos"
 precision           = "bfloat16"                         # was [model.parallelism].precision
 
 [model.backbone]
-model_name = "Qwen/Qwen3-VL-8B-Instruct"
+model_name = "Qwen/Qwen3-VL-32B-Instruct"
 
 [model.ema]
 enabled         = false
@@ -34,9 +43,9 @@ rate            = 0.1
 iteration_shift = 0
 
 [model.parallelism]
-data_parallel_shard_degree      = 8
-data_parallel_replicate_degree  = -1
-context_parallel_shard_degree   = 1
+data_parallel_shard_degree      = -1                     # super: FSDP full shard, auto from WORLD_SIZE (4- or 8-GPU)
+data_parallel_replicate_degree  = 1
+context_parallel_shard_degree   = 1                      # raise to 2 (needs even GPU count) if the 32B run OOMs
 cfg_parallel_shard_degree       = 1
 
 [model.compile]


### PR DESCRIPTION
Add the Cosmos3-Super VideoPhy-2 Reasoner SFT recipe for cookbook, including a self- contained launcher, TOML configuration, and README entries.

The launcher automatically builds the merged Cosmos3-Super-Reasoner checkpoint and passes it through the `backbone.safetensors_path `override.

Use a uniform learning rate of `1e-6`, matching the framework recipe.