### PR TITLE
docs(reasoner): add backend memory-footprint guidance

### DIFF
--- a/cookbooks/cosmos3/reasoner/README.md
+++ b/cookbooks/cosmos3/reasoner/README.md
@@ -7,6 +7,27 @@ Environment setup for every backend is centralized in the shared
 [Cosmos3 cookbooks environment setup](../README.md) guide; each backend below
 links to the section you need.
 
+## Choosing a backend (memory footprint)
+
+Cosmos3 ships as a **unified omni checkpoint** (Reasoner + generator/diffusion), so
+how much GPU memory you pay depends on the backend:
+
+- The **Cosmos Framework** backend loads the **full omni weights** (Reasoner *plus*
+  the generator: video VAE, audio tokenizer, and diffusion expert). It therefore
+  uses the most memory — even for text-only reasoner inference. `model_mode=reasoner`
+  only changes the execution path; it does **not** unload the generator weights.
+- The **vLLM**, **Transformers**, and **NIM** backends load **only the Reasoner (VLM)
+  weights**, so they use much less memory.
+
+**If you need to save GPU memory for reasoner-only inference, use vLLM,
+Transformers, or NIM.** Reach for the Cosmos Framework backend only when you also
+need generation.
+
+For example, on a single GPU the **Cosmos3-Nano** Reasoner needs roughly **~34 GB**
+with the Cosmos Framework backend versus **~16–17 GB** with vLLM / Transformers / NIM
+— about half. Larger tiers (e.g. Cosmos3-Super) use more in absolute terms, but the
+same full-omni-vs-reasoner-only gap applies.
+
 ## Reasoner Prompt Guide
 
 See the [Reasoner Prompt Guide](./reasoner_prompt_guide.md).


### PR DESCRIPTION
## Summary

Adds a **Choosing a backend (memory footprint)** section to the Cosmos3 Reasoner cookbook README, so users sizing hardware for **reasoner-only inference** know how to avoid over-provisioning.

Key points:
- The **Cosmos Framework** backend loads the **full omni checkpoint** (Reasoner + generator: video VAE, audio tokenizer, diffusion expert) even for text-only reasoner inference. `model_mode=reasoner` only changes the execution path — it does **not** unload the generator weights.
- The **vLLM**, **Transformers**, and **NIM** backends load **only the Reasoner (VLM) weights**, so they use much less memory.
- Recommendation: for reasoner-only inference, use vLLM / Transformers / NIM; reach for the Cosmos Framework backend only when you also need generation.

## Measured numbers

Single-GPU (GB200), **Cosmos3-Nano**, measured this week:

| Backend | Loads | GPU weight memory |
|---|---|---|
| Cosmos Framework | Full omni | **~34 GB** (peak 34.9 GiB) |
| Transformers | Reasoner tower only | **~16 GB** (16.3 GiB) |
| vLLM | Reasoner tower only | **~17 GB** (16.8 GiB) |

Consistent with the existing `run_with_transformers.ipynb` note (~17 GiB for the Reasoner tower).

Context: raised by a customer asking how to size hardware when the generator is not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)