### PR TITLE
Release: Cosmos3-Edge and Distillation support (Sync from cosmos-private/main into origin/main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
   - [Examples](#examples)
   - [Inference Benchmarks](#inference-benchmarks)
   - [Finetune](#finetune)
+  - [Export and Convert Checkpoints](#export-and-convert-checkpoints)
+  - [Distill](#distill)
   - [Limitations](#limitations)
 - [Ecosystem](#ecosystem)
 - [News](#news)
@@ -79,13 +81,90 @@ Cosmos 3 is an omnimodal world model built on a unified Mixture-of-Transformers 
 
 ### Model Family
 
-| Model | Size | Primary Capability |
-|---------|---------:|---------|
-| **[Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano)** | 16B | Compact omnimodal world model for multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI. |
-| **[Cosmos3-Super](https://huggingface.co/nvidia/Cosmos3-Super)** | 64B | Frontier-scale omnimodal world model for advanced multimodal understanding, world simulation, future prediction, action reasoning, and Physical AI. |
-| **[Cosmos3-Super-Text2Image](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image)** | 64B | High-fidelity text-to-image generation. |
-| **[Cosmos3-Super-Image2Video](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video)** | 64B | Temporally coherent image-to-video generation. |
-| **[Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID)** | 16B | Vision-language robot policy for DROID manipulation and control. |
+<table width="100%">
+  <thead>
+    <tr>
+      <th align="left" width="16%"></th>
+      <th align="left" width="28%"><a href="https://huggingface.co/nvidia/Cosmos3-Super">Cosmos3-Super</a></th>
+      <th align="left" width="28%"><a href="https://huggingface.co/nvidia/Cosmos3-Nano">Cosmos3-Nano</a></th>
+      <th align="left" width="28%"><a href="https://huggingface.co/nvidia/Cosmos3-Edge">Cosmos3-Edge</a></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Size</strong></td>
+      <td>64B</td>
+      <td>16B</td>
+      <td>4B</td>
+    </tr>
+    <tr>
+      <td><strong>Recommended Hardware</strong></td>
+      <td>Data Center: H200 / B200 / GB200</td>
+      <td>Data Center and Workstation: RTX Pro 6000 / H100 / B200</td>
+      <td>Edge and On-Device: Jetson AGX Orin / Thor / RTX Pro 6000</td>
+    </tr>
+    <tr>
+      <td><strong>Input</strong></td>
+      <td>Text / Image / Video / Action</td>
+      <td>Text / Image / Video / Action</td>
+      <td>Text / Image / Video<sup>2</sup> / Action</td>
+    </tr>
+    <tr>
+      <td><strong>Output</strong></td>
+      <td>Text / Image / Video / Sound<sup>1</sup> / Action</td>
+      <td>Text / Image / Video / Sound<sup>1</sup> / Action</td>
+      <td>Text / Image / Video / Action</td>
+    </tr>
+    <tr>
+      <td><strong>Suited For</strong></td>
+      <td>Data center deployment; high quality synthetic data generation; teacher model for distillation</td>
+      <td>Flexible hardware range; balanced speed and quality; strong base model to post-train</td>
+      <td>Edge deployment; real-time robotic policy; real-time visual reasoning</td>
+    </tr>
+    <tr>
+      <td><strong>Model Variants</strong></td>
+      <td>
+        SoTA image/video generation:
+        <ul>
+          <li><a href="https://huggingface.co/nvidia/Cosmos3-Super-Text2Image">Cosmos3-Super-Text2Image</a></li>
+          <li><a href="https://huggingface.co/nvidia/Cosmos3-Super-Image2Video">Cosmos3-Super-Image2Video</a></li>
+        </ul>
+        SoTA quality with 17-25x speed up:
+        <ul>
+          <li><a href="https://huggingface.co/nvidia/Cosmos3-Super-Text2Image-4Step">Cosmos3-Super-Text2Image-4Step</a></li>
+          <li><a href="https://huggingface.co/nvidia/Cosmos3-Super-Image2Video-4Step">Cosmos3-Super-Image2Video-4Step</a></li>
+        </ul>
+        Less memory, higher speed:
+        <ul>
+          <li>FP8/NVFP4 (coming soon)</li>
+        </ul>
+      </td>
+      <td>
+        SoTA World Action Model:
+        <ul>
+          <li><a href="https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID">Cosmos3-Nano-Policy-DROID</a></li>
+        </ul>
+        Less memory, higher speed:
+        <ul>
+          <li>FP8/NVFP4 (coming soon)</li>
+        </ul>
+      </td>
+      <td>
+        Real-time World Action Model:
+        <ul>
+          <li><a href="https://huggingface.co/nvidia/Cosmos3-Edge-Policy-DROID">Cosmos3-Edge-Policy-DROID</a></li>
+        </ul>
+        Less memory, higher speed:
+        <ul>
+          <li>FP8/NVFP4 (coming soon)</li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<sup>1</sup> The models generate sound along with the video, not standalone.<br>
+<sup>2</sup> Cosmos3-Edge currently doesn't support video-to-video transfer.
 
 
 ### Supported Generation Settings
@@ -99,6 +178,8 @@ Cosmos 3 is an omnimodal world model built on a unified Mixture-of-Transformers 
 | Precision         | BF16 tested                             |
 | Operating system  | Linux                                   |
 | GPU architectures | NVIDIA Ampere, Hopper, and Blackwell    |
+
+Cosmos3-Edge only supports 256p and 480p resolution, 12–30 fps, and 50–150 frames.
 
 ### Input and Output
 
@@ -992,7 +1073,7 @@ The Cosmos Framework requires `uv >= 0.11.3` (enforced via its `pyproject.toml`)
 
 ### Examples
 
-We are building examples that show Cosmos 3 capabilities end to end, including world generation, world understanding, captioning, temporal localization, grounding, and physical reasoning. Each example is a self-contained script or notebook you can run from this repository.
+We are building examples that show Cosmos 3 Super/Nano/Edge capabilities end to end, including world generation, world understanding, captioning, temporal localization, grounding, and physical reasoning. Each example is a self-contained script or notebook you can run from this repository.
 
 | Example | Surface | Workflows demonstrated | Open | nbviewer |
 | --- | --- | --- | --- | --- |
@@ -1002,10 +1083,10 @@ We are building examples that show Cosmos 3 capabilities end to end, including w
 | Generator (audiovisual) with NIM | Generator | Text2Video and Image2Video only, against the prebuilt `Cosmos3-Generator` NIM; requests use `POST /v1/infer` and decode JSON `b64_video` responses. | [Notebook](cookbooks/cosmos3/generator/audiovisual/run_with_nim.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/audiovisual/run_with_nim.ipynb) |
 | Generator (audiovisual) with SGLang | Generator | Text-to-image, plus text-to-video and image-to-video each with sound on or off, against an OpenAI-compatible SGLang server. | [Notebook](cookbooks/cosmos3/generator/audiovisual/run_with_sglang.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/audiovisual/run_with_sglang.ipynb) |
 | Forward dynamics with Cosmos Framework | Generator | Forward dynamics: action-conditioned future-observation prediction for AV, DROID, and UMI, through the `cosmos_framework.scripts.inference` entrypoint. | [Notebook](cookbooks/cosmos3/generator/action/run_fd_with_cosmos_framework.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_fd_with_cosmos_framework.ipynb) |
-| Forward dynamics with vLLM-Omni | Generator | Forward dynamics: action-conditioned future-observation prediction for AV, DROID, and UMI, against an OpenAI-compatible vLLM-Omni server. | [Notebook](cookbooks/cosmos3/generator/action/run_fd_with_vllm.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_fd_with_vllm.ipynb) |
+| Forward dynamics with vLLM-Omni | Generator | Forward dynamics: action-conditioned future-observation prediction for AV, DROID, and UMI, against an OpenAI-compatible vLLM-Omni server. | [Notebook](cookbooks/cosmos3/generator/action/run_fd_with_vllm_omni.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_fd_with_vllm_omni.ipynb) |
 | Forward dynamics with SGLang | Generator | Forward dynamics: action-conditioned future-observation prediction for AV, DROID, and UMI, against an OpenAI-compatible SGLang server. | [Notebook](cookbooks/cosmos3/generator/action/run_fd_with_sglang.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_fd_with_sglang.ipynb) |
 | Inverse dynamics with Cosmos Framework | Generator | Inverse dynamics: ego-motion trajectory prediction from input AV video, through the `cosmos_framework.scripts.inference` entrypoint. | [Notebook](cookbooks/cosmos3/generator/action/run_id_with_cosmos_framework.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_id_with_cosmos_framework.ipynb) |
-| Inverse dynamics with vLLM-Omni | Generator | Inverse dynamics: ego-motion trajectory prediction from input AV video, against an OpenAI-compatible vLLM-Omni server. | [Notebook](cookbooks/cosmos3/generator/action/run_id_with_vllm.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_id_with_vllm.ipynb) |
+| Inverse dynamics with vLLM-Omni | Generator | Inverse dynamics: ego-motion trajectory prediction from input AV video, against an OpenAI-compatible vLLM-Omni server. | [Notebook](cookbooks/cosmos3/generator/action/run_id_with_vllm_omni.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_id_with_vllm_omni.ipynb) |
 | Inverse dynamics with SGLang | Generator | Inverse dynamics: ego-motion trajectory prediction from input AV video, against an OpenAI-compatible SGLang server. | [Notebook](cookbooks/cosmos3/generator/action/run_id_with_sglang.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/action/run_id_with_sglang.ipynb) |
 | Transfer with Cosmos Framework | Generator | Video transfer: edge, blur, depth, segmentation, and world-scenario controls with captions, through the `cosmos_framework.scripts.inference` entrypoint. | [Notebook](cookbooks/cosmos3/generator/transfer/run_video_transfer_with_cosmos_framework.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/generator/transfer/run_video_transfer_with_cosmos_framework.ipynb) |
 | Reasoner with Cosmos Framework | Reasoner | Text and image reasoning: detailed captioning, robot task planning, 2D grounding, describe-anything, and action-trajectory prompts, through the `cosmos_framework.scripts.inference` entrypoint. | [Notebook](cookbooks/cosmos3/reasoner/run_with_cosmos_framework.ipynb) | [![Render with nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.org/github/nvidia/cosmos/blob/main/cookbooks/cosmos3/reasoner/run_with_cosmos_framework.ipynb) |
@@ -1014,29 +1095,68 @@ We are building examples that show Cosmos 3 capabilities end to end, including w
 
 ### Inference Benchmarks
 
-Cosmos 3 latency and serving numbers live in [`inference_benchmarks.md`](inference_benchmarks.md). Generator sections report diffusion-path latency (seconds) by GPU, engine, resolution, and tensor-parallel width; Reasoner sections report vLLM serving metrics under concurrent load. Empty cells mean a combination has not been measured yet, not that it is unsupported.
+Cosmos 3 latency and serving results live in [`inference_benchmarks.md`](inference_benchmarks.md). Generator sections report visual-generation and world-model latency in seconds across GPUs and integrated computing platforms, including image and video generation, forward and inverse dynamics, and policy generation. Reasoner sections report vLLM serving metrics under concurrent load, with additional eager Transformers measurements for embedded platforms. Empty cells mean a combination has not been measured yet, not that it is unsupported.
 
 | Benchmark | Surface | Model | What it covers |
 | --- | --- | --- | --- |
-| [Cosmos3-Nano generator](inference_benchmarks.md#cosmos3-nano-generator) | Generator | Cosmos3-Nano | Text-to-image, text-to-video, and image-to-video latency across PyTorch, vLLM-Omni, and Diffusers |
+| [Cosmos3-Edge generator](inference_benchmarks.md#cosmos3-edge-generator) | Generator | Cosmos3-Edge | Image-to-video, forward dynamics, inverse dynamics, and DROID policy latency across PyTorch and vLLM-Omni on data center, workstation, and embedded platforms |
+| [Cosmos3-Nano generator](inference_benchmarks.md#cosmos3-nano-generator) | Generator | Cosmos3-Nano | Text-to-image, text-to-video, and image-to-video latency across PyTorch, vLLM-Omni, Diffusers, and NIM |
 | [Cosmos3-Super generator](inference_benchmarks.md#cosmos3-super-generator) | Generator | Cosmos3-Super | The same modalities and engines at the larger checkpoint scale |
+| [Cosmos3-Edge reasoner](inference_benchmarks.md#cosmos3-edge-reasoner) | Reasoner | Cosmos3-Edge | vLLM serving metrics on RTX PRO GPUs and eager Transformers prefill, decode, and end-to-end latency on embedded platforms |
 | [Cosmos3-Nano reasoner](inference_benchmarks.md#cosmos3-nano-reasoner) | Reasoner | Cosmos3-Nano | vLLM serving metrics — TTFT, request latency, and throughput at concurrency 1/64/128/256 |
 | [Cosmos3-Super reasoner](inference_benchmarks.md#cosmos3-super-reasoner) | Reasoner | Cosmos3-Super | The same serving metrics at the larger checkpoint scale; coverage is sparser than Nano |
 
 ### Finetune
 
-Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookbooks below. Each recipe is a self-contained launch script: a single `bash launch_sft_<recipe>.sh` prepares or validates the data, prepares the base checkpoint, and runs 8×H100 training.
+Post-train Cosmos 3 on your own data with the supervised fine-tuning (SFT) cookbooks below. Each recipe is a self-contained launch script: a single `bash launch_sft_<recipe>.sh` prepares or validates the data, prepares any needed base checkpoint, and runs 8×H100 training.
 
 | Example | Surface | Model | What it covers | Script |
 | --- | --- | --- | --- | --- |
 | [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT on captioned video | [`launch_sft_vision_nano.sh`](cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_nano.sh) |
 | [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Super | LoRA SFT on captioned video | [`launch_sft_vision_super.sh`](cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh) |
-| [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT for action policy on the DROID dataset | [`launch_sft_action_policy_droid.sh`](cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid.sh) |
+| [Vision generator SFT](cookbooks/cosmos3/generator/audiovisual/finetune/README.md) | Generator | Cosmos3-Edge | Full SFT on captioned video | [`launch_sft_vision_edge.sh`](cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_edge.sh) |
+| [Policy-DROID SFT](cookbooks/cosmos3/generator/action/finetune/README.md) | Generator | Cosmos3-Nano | Full SFT for action policy on the DROID dataset | [`launch_sft_action_policy_droid_nano.sh`](cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid_nano.sh) |
 | [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Alignment SFT on LLaVA-OneVision | [`launch_sft_llava_ov.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_llava_ov.sh) |
 | [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Nano | Physical-plausibility SFT on VideoPhy-2 | [`launch_sft_videophy2_nano.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_nano.sh) |
 | [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Super | Physical-plausibility SFT on VideoPhy-2 | [`launch_sft_videophy2_super.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_super.sh) |
+| [Reasoner SFT](cookbooks/cosmos3/reasoner/finetune/README.md) | Reasoner | Cosmos3-Edge | Physical-plausibility SFT on VideoPhy-2 | [`launch_sft_videophy2_edge.sh`](cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_edge.sh) |
 
 These cookbooks run on the [Cosmos Framework](https://github.com/NVIDIA/cosmos-framework), NVIDIA's end-to-end Physical AI framework for training and serving world models. For the full post-training reference — every config field, raw `torchrun`, resuming, and advanced parallelism — see the [Cosmos Framework training guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/training.md).
+
+### Export and Convert Checkpoints
+
+Training writes sharded PyTorch Distributed Checkpoints (DCP) under `outputs/train/<project>/<group>/<name>/checkpoints/`. Two Cosmos Framework scripts turn a finished run into portable, inference-ready formats. Run both from a framework checkout with its venv active (see the recipe READMEs for setup).
+
+**Step 1 — Export to Hugging Face safetensors** (`export_model`). Converts the DCP checkpoint into a Hugging Face safetensors directory:
+
+```shell
+RUN_DIR=outputs/train/<project>/<group>/<name>
+CKPT=$RUN_DIR/checkpoints/$(cat "$RUN_DIR/checkpoints/latest_checkpoint.txt")
+python -m cosmos_framework.scripts.export_model \
+    --checkpoint-path "$CKPT" --config-file "$RUN_DIR/config.yaml" -o "$RUN_DIR/model"
+```
+
+The exported `$RUN_DIR/model` is what the Transformers, vLLM, and Cosmos Framework inference paths depend on.
+
+**Step 2 — Convert to Diffusers** (`convert_model_to_diffusers`). Converts the Step 1 export into a Diffusers pipeline (`transformer/`, `vae/`, `scheduler/`, …):
+
+```shell
+python -m cosmos_framework.scripts.convert_model_to_diffusers \
+    --checkpoint-path "$RUN_DIR/model" -o "$RUN_DIR/diffusers"
+```
+
+The input is the safetensors directory from Step 1 (not a raw DCP), so run the export first.
+
+For the full export/convert reference and per-model notes, see the [Cosmos Framework training guide](https://github.com/NVIDIA/cosmos-framework/blob/main/docs/training.md#export-checkpoint-to-hugging-face-safetensors).
+
+### Distill
+
+Distill the Cosmos3-Super text-to-image and image-to-video teachers into four-step DMD2 students with short training, resume, and student-only checkpoint export recipes. These recipes demonstrate the workflow on public sample data; they are not production-quality reproduction recipes.
+
+| Example | Surface | Teacher → student | What it covers | Script |
+| --- | --- | --- | --- | --- |
+| [Text-to-image DMD2 distillation](cookbooks/cosmos3/generator/audiovisual/distill/README.md) | Generator | Cosmos3-Super-Text2Image → Cosmos3-Super-Text2Image-4Step | Short T2I training, resume, and student-only export | [`launch_distillation_t2i.sh`](cookbooks/cosmos3/generator/audiovisual/distill/launch_distillation_t2i.sh) |
+| [Image-to-video DMD2 distillation](cookbooks/cosmos3/generator/audiovisual/distill/README.md) | Generator | Cosmos3-Super-Image2Video → Cosmos3-Super-Image2Video-4Step | Short I2V training, resume, and student-only export | [`launch_distillation_i2v.sh`](cookbooks/cosmos3/generator/audiovisual/distill/launch_distillation_i2v.sh) |
 
 ### Limitations
 

--- a/cookbooks/cosmos3/README.md
+++ b/cookbooks/cosmos3/README.md
@@ -264,6 +264,19 @@ vllm serve nvidia/Cosmos3-Super \
   --port "$VLLM_PORT"
 ```
 
+**Cosmos3-Edge** (single GPU, port 8000):
+
+```bash
+CUDA_VISIBLE_DEVICES=0 \
+vllm serve nvidia/Cosmos3-Edge \
+  --tensor-parallel-size 1 \
+  --mm-encoder-tp-mode data \
+  --async-scheduling \
+  --allowed-local-media-path "$(dirname "$(pwd)")" \
+  --media-io-kwargs '{"video": {"num_frames": -1}}' \
+  --port 8000
+```
+
 The Super notebook polls `/health` for up to 1800 seconds on first start while CUDA
 graphs compile.
 
@@ -357,6 +370,58 @@ docker run --runtime nvidia --gpus all \
   -p "${COSMOS3_HOST_PORT}:8000" --ipc=host \
   vllm/vllm-omni:cosmos3 \
   vllm serve nvidia/Cosmos3-Super \
+    --omni \
+    --model-class-name Cosmos3OmniDiffusersPipeline \
+    --allowed-local-media-path / \
+    --tensor-parallel-size 4 \
+    --enable-layerwise-offload \
+    --port 8000 \
+    --init-timeout 1800
+```
+
+**Cosmos3-Edge** (single GPU):
+
+```bash
+docker run --runtime nvidia --gpus all \
+  -v "${HF_HOME}:/root/.cache/huggingface" \
+  -v "${COSMOS3_WORKDIR}:/workspace" \
+  -p "${COSMOS3_HOST_PORT}:8000" --ipc=host \
+  vllm/vllm-omni:cosmos3 \
+  vllm serve nvidia/Cosmos3-Edge \
+    --omni \
+    --model-class-name Cosmos3OmniDiffusersPipeline \
+    --allowed-local-media-path / \
+    --port 8000 \
+    --init-timeout 1800
+```
+
+**Cosmos3-Super-Text2Image-4Step** (all GPUs; add tensor parallelism and layerwise offload):
+
+```bash
+docker run --runtime nvidia --gpus all \
+  -v "${HF_HOME}:/root/.cache/huggingface" \
+  -v "${COSMOS3_WORKDIR}:/workspace" \
+  -p "${COSMOS3_HOST_PORT}:8000" --ipc=host \
+  vllm/vllm-omni:cosmos3 \
+  vllm serve nvidia/Cosmos3-Super-Text2Image-4Step \
+    --omni \
+    --model-class-name Cosmos3OmniDiffusersPipeline \
+    --allowed-local-media-path / \
+    --tensor-parallel-size 4 \
+    --enable-layerwise-offload \
+    --port 8000 \
+    --init-timeout 1800
+```
+
+**Cosmos3-Super-Image2Video-4Step** (all GPUs; add tensor parallelism and layerwise offload):
+
+```bash
+docker run --runtime nvidia --gpus all \
+  -v "${HF_HOME}:/root/.cache/huggingface" \
+  -v "${COSMOS3_WORKDIR}:/workspace" \
+  -p "${COSMOS3_HOST_PORT}:8000" --ipc=host \
+  vllm/vllm-omni:cosmos3 \
+  vllm serve nvidia/Cosmos3-Super-Image2Video-4Step \
     --omni \
     --model-class-name Cosmos3OmniDiffusersPipeline \
     --allowed-local-media-path / \

--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -86,7 +86,7 @@ visualize the generated videos:
   forward dynamics for AV, DROID, and UMI robotics examples using Cosmos3-Nano.
 - [`run_id_with_cosmos_framework.ipynb`](./run_id_with_cosmos_framework.ipynb) —
   inverse dynamics, predicting ego-motion trajectories from input AV videos using Cosmos3-Nano.
-- [`run_policy_with_cosmos_framework.md`](./run_policy_with_cosmos_framework.md) - policy, predicting future observations and action trajectories for DROID robot using Cosmos3-Nano-Policy-DROID.
+- [`run_policy_with_cosmos_framework.md`](./run_policy_with_cosmos_framework.md) - policy, predicting future observations and action trajectories for DROID robot using Cosmos3-Nano-Policy-DROID and Cosmos3-Edge-Policy-DROID.
 
 ## Run with vLLM-Omni
 
@@ -105,8 +105,8 @@ curl http://localhost:8001/v1/models
 Forward-dynamics requests are multipart `POST`s to `/v1/videos` — a start image
 under `files={"input_reference": ...}` plus an `extra_params` payload carrying the
 action trajectory. The vLLM notebooks use these diffusion defaults for action
-generation (see [`run_fd_with_vllm.ipynb`](./run_fd_with_vllm.ipynb) and
-[`run_id_with_vllm.ipynb`](./run_id_with_vllm.ipynb)):
+generation (see [`run_fd_with_vllm_omni.ipynb`](./run_fd_with_vllm_omni.ipynb) and
+[`run_id_with_vllm_omni.ipynb`](./run_id_with_vllm_omni.ipynb)):
 
 | Field | Value |
 | --- | --- |
@@ -122,9 +122,9 @@ including autoregressive chunked generation for the robotics examples.
 The vLLM-Omni notebooks send requests through the OpenAI-compatible video API and
 write outputs under `outputs/cosmos3_action_vllm/`:
 
-- [`run_fd_with_vllm.ipynb`](./run_fd_with_vllm.ipynb) — forward dynamics for AV,
+- [`run_fd_with_vllm_omni.ipynb`](./run_fd_with_vllm_omni.ipynb) — forward dynamics for AV,
   DROID, and UMI robotics examples.
-- [`run_id_with_vllm.ipynb`](./run_id_with_vllm.ipynb) — inverse dynamics,
+- [`run_id_with_vllm_omni.ipynb`](./run_id_with_vllm_omni.ipynb) — inverse dynamics,
   predicting ego-motion trajectories from input AV videos.
 
 ## Post-Train for Cosmos3-Nano-Policy-DROID
@@ -135,7 +135,7 @@ launch-script pattern as the other Cosmos3 finetune cookbooks while delegating
 the canonical training implementation to Cosmos Framework.
 
 The same [action-policy SFT cookbook](./finetune/README.md) also covers **LIBERO-10**
-(`launch_sft_action_policy_libero.sh`) — fine-tuning Cosmos3-Nano on the `libero_10`
+(`launch_sft_action_policy_libero_10_nano.sh`) — fine-tuning Cosmos3-Nano on the `libero_10`
 simulation benchmark with the same launch-script pattern.
 
 ## TODO

--- a/cookbooks/cosmos3/generator/action/finetune/README.md
+++ b/cookbooks/cosmos3/generator/action/finetune/README.md
@@ -7,16 +7,16 @@ This example demonstrates supervised fine-tuning (SFT) of [Cosmos3-Nano](https:/
 
 | Recipe | Launch shell | Base model | Dataset |
 | --- | --- | --- | --- |
-| Policy-DROID SFT | `launch_sft_action_policy_droid.sh` | Cosmos3-Nano | [Cosmos3-DROID](https://huggingface.co/datasets/nvidia/Cosmos3-DROID) success split |
-| Policy-LIBERO-10 SFT (A) | `launch_sft_action_policy_libero.sh` | Cosmos3-Nano | [LIBERO_LeRobot_v3](https://huggingface.co/datasets/nvidia/LIBERO_LeRobot_v3) `libero_10` |
-| Policy-LIBERO-all SFT (B) | `launch_sft_action_policy_libero_all.sh` | Cosmos3-Nano | [LIBERO_LeRobot_v3](https://huggingface.co/datasets/nvidia/LIBERO_LeRobot_v3) all 4 suites |
+| Policy-DROID SFT (Nano) | `launch_sft_action_policy_droid_nano.sh` | Cosmos3-Nano | [Cosmos3-DROID](https://huggingface.co/datasets/nvidia/Cosmos3-DROID) success split |
+| Policy-LIBERO-10 SFT (Nano) | `launch_sft_action_policy_libero_10_nano.sh` | Cosmos3-Nano | [LIBERO_LeRobot_v3](https://huggingface.co/datasets/nvidia/LIBERO_LeRobot_v3) `libero_10` |
+| Policy-LIBERO-all SFT (Nano) | `launch_sft_action_policy_libero_all_nano.sh` | Cosmos3-Nano | [LIBERO_LeRobot_v3](https://huggingface.co/datasets/nvidia/LIBERO_LeRobot_v3) all 4 suites |
 
 The DROID recipe uses the registered `action_policy_droid_nano` experiment: `joint_pos` 8-D actions, proprioceptive state, `concat_view` 480p video, chunk length 32, episode-shuffle streaming, JSON-formatted action prompts (`format_prompt_as_json=True`), and the optional `keep_ranges_1_0_1.json` window filter. The reference reproduction runs lr 2e-4 (cosine, cycle 100000), generator loss_scale 10, global batch 8192 (HSDP 32x8 = 256 ranks; GB200 reference, 64 nodes x 4), for 10000 iters. The action prompt is serialized as JSON at both train and eval time, so evaluation must use the matching JSON prompt format.
 
-The LIBERO recipe uses `frame_wise_relative` rot6d 10-D actions, `quantile_rot` normalization, `concat_view` (third-person + wrist) at 20 fps, lr 5e-5 / warmup 500 / cycle 16000, global batch 2048 (HSDP 2x8). To match the LIBERO-10 results reported in Cosmos3, we provide **two presets**:
+The LIBERO recipe uses `frame_wise_relative` rot6d 10-D actions, `quantile_rot` normalization, `concat_view` (third-person + wrist) at 20 fps, lr 5e-5 / warmup 500 / cycle 16000, global batch 2048 (HSDP 2x8). To match the LIBERO-10 results reported in Cosmos3, we provide two presets:
 
-- **(A) libero_10-only** — `action_policy_libero_nano` + `launch_sft_action_policy_libero.sh`; trains on `libero_10` alone (max_iter 2000).
-- **(B) libero-all** — `action_policy_libero_all_nano` + `launch_sft_action_policy_libero_all.sh`; equal mix of all 4 LIBERO suites, which needs longer training (max_iter 5000).
+- **libero-10** — `action_policy_libero_nano` + `launch_sft_action_policy_libero_10_nano.sh`; trains on `libero_10` alone (max_iter 2000).
+- **libero-all** — `action_policy_libero_all_nano` + `launch_sft_action_policy_libero_all_nano.sh`; equal mix of all 4 LIBERO suites, which needs longer training (max_iter 5000).
 
 For a runnable egocentric hand-pose data conversion example, see
 [`README_egocentric_hand_action.md`](./README_egocentric_hand_action.md). It
@@ -46,7 +46,7 @@ uvx hf@latest download \
     --repo-type dataset \
     --local-dir data/Cosmos3-DROID
 
-bash launch_sft_action_policy_droid.sh
+bash launch_sft_action_policy_droid_nano.sh
 ```
 
 The launcher is a complete local wrapper for the public cookbook:
@@ -55,7 +55,7 @@ The launcher is a complete local wrapper for the public cookbook:
 - downloads `Wan2.2_VAE.pth` if needed
 - converts `Cosmos3-Nano` to a local DCP checkpoint if needed
 - downloads `keep_ranges_1_0_1.json` if needed
-- launches training with `action_policy_droid_repro.toml`
+- launches training with `action_policy_droid_nano.toml`
 
 The script intentionally stays close to the `cosmos-framework` example launcher: `DATASET_PATH`
 is bridged to `DROID_ROOT`, `BASE_CHECKPOINT_PATH` and `WAN_VAE_PATH` are exported for the TOML,
@@ -70,7 +70,7 @@ export DATASET_PATH=/scratch/Cosmos3-DROID/success
 export BASE_CHECKPOINT_PATH=/scratch/checkpoints/Cosmos3-Nano
 export WAN_VAE_PATH=/scratch/checkpoints/wan22_vae/Wan2.2_VAE.pth
 export FILTER_PATH=/scratch/droid/keep_ranges_1_0_1.json
-bash launch_sft_action_policy_droid.sh
+bash launch_sft_action_policy_droid_nano.sh
 ```
 
 The committed TOML pins the GB200 reference shape (HSDP 32x8 = 256 ranks, global
@@ -85,7 +85,7 @@ export EXTRA_TAIL_OVERRIDES=" \
   model.config.parallelism.data_parallel_replicate_degree=1 \
   dataloader_train.max_samples_per_batch=32 \
 "
-bash launch_sft_action_policy_droid.sh
+bash launch_sft_action_policy_droid_nano.sh
 ```
 
 To reproduce the reference at full global batch 8192 on fewer GPUs, keep
@@ -97,31 +97,31 @@ To reproduce the reference at full global batch 8192 on fewer GPUs, keep
 Each launcher stages its dataset (auto-downloaded if missing), downloads the Wan
 VAE, converts the base checkpoint, and trains.
 
-**Preset A — libero_10-only:**
+**libero-10:**
 
 ```shell
-bash launch_sft_action_policy_libero.sh
+bash launch_sft_action_policy_libero_10_nano.sh
 ```
 
 - downloads `nvidia/LIBERO_LeRobot_v3` `libero_10` to `data/LIBERO_LeRobot_v3/libero_10` if missing
-- launches training with `action_policy_libero_repro.toml` (max_iter 2000)
+- launches training with `action_policy_libero_10_nano.toml` (max_iter 2000)
 
-**Preset B — libero-all (4-suite equal mix):**
+**libero-all:**
 
 ```shell
-bash launch_sft_action_policy_libero_all.sh
+bash launch_sft_action_policy_libero_all_nano.sh
 ```
 
 - downloads all 4 suites of `nvidia/LIBERO_LeRobot_v3` to `data/LIBERO_LeRobot_v3` if missing
-- launches training with `action_policy_libero_all_repro.toml` (max_iter 5000; it needs longer to converge)
+- launches training with `action_policy_libero_all_nano.toml` (max_iter 5000; it needs longer to converge)
 
 Both download `Wan2.2_VAE.pth` and convert `Cosmos3-Nano` to a local DCP checkpoint if needed.
 Relocate inputs via env vars, or run a short smoke test:
 
 ```shell
-export LIBERO_ROOT=/scratch/LIBERO_LeRobot_v3/libero_10   # preset B: the parent dir, /scratch/LIBERO_LeRobot_v3
+export LIBERO_ROOT=/scratch/LIBERO_LeRobot_v3/libero_10   # libero-all preset: the parent dir, /scratch/LIBERO_LeRobot_v3
 export EXTRA_TAIL_OVERRIDES="job.wandb_mode=disabled trainer.max_iter=10 checkpoint.save_iter=10 dataloader_train.max_samples_per_batch=32"
-bash launch_sft_action_policy_libero.sh
+bash launch_sft_action_policy_libero_10_nano.sh
 ```
 
 Checkpoints are saved every 500 iters.
@@ -145,6 +145,17 @@ python -m cosmos_framework.scripts.export_model \
 ```
 
 Use the exported `$RUN_DIR/model` with the [Cosmos3-Nano-Policy-DROID inference cookbook](../run_policy_with_cosmos_framework.md).
+
+## Convert to Diffusers
+
+Convert the export into a Diffusers pipeline:
+
+```shell
+python -m cosmos_framework.scripts.convert_model_to_diffusers \
+    --checkpoint-path "$RUN_DIR/model" -o "$RUN_DIR/diffusers"
+```
+
+The input is the Hugging Face directory produced by `export_model` above (not a raw DCP checkpoint), so run the export first. See the [Export and Convert Checkpoints](../../../../../README.md#export-and-convert-checkpoints) overview for details.
 
 ## Advanced configuration
 

--- a/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid_nano.sh
+++ b/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_droid_nano.sh
@@ -7,7 +7,7 @@
 # 8192); on fewer GPUs override data_parallel_replicate_degree / grad_accum_iter
 # (see README). Set NNODES / NODE_RANK / MASTER_ADDR for multi-node.
 # Run from this folder with the cosmos-framework venv active (see README):
-#   bash launch_sft_action_policy_droid.sh
+#   bash launch_sft_action_policy_droid_nano.sh
 # It prepares the small dependencies, checks for the staged DROID dataset, and trains.
 # Paths are fixed under this (git-ignored) folder, matching the reasoner finetune
 # wrappers, while the TOML and tail-overrides match the cosmos-framework example.
@@ -15,7 +15,7 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-TOML_FILE="toml/sft_config/action_policy_droid_repro.toml"
+TOML_FILE="$PWD/toml/sft_config/action_policy_droid_nano.toml"
 : "${DATASET_PATH:=$PWD/data/Cosmos3-DROID/success}"
 : "${BASE_CHECKPOINT_PATH:=$PWD/checkpoints/Cosmos3-Nano}"
 : "${WAN_VAE_PATH:=$PWD/checkpoints/wan22_vae/Wan2.2_VAE.pth}"
@@ -76,6 +76,9 @@ TORCHRUN_ARGS+=(--master_port="${MASTER_PORT:-50012}")
 [[ -n "${MASTER_ADDR:-}" ]] && TORCHRUN_ARGS+=(--master_addr="$MASTER_ADDR")
 
 OUTPUT_ROOT="${OUTPUT_ROOT:-$PWD/outputs/train}"
+# The model configs reference their packaged JSONs relative to the framework
+# root, so run torchrun from there (all recipe paths above are absolute).
+cd "$(python -c 'import pathlib, cosmos_framework; print(pathlib.Path(cosmos_framework.__file__).resolve().parents[1])')"
 IMAGINAIRE_OUTPUT_ROOT="${IMAGINAIRE_OUTPUT_ROOT:-$OUTPUT_ROOT}" torchrun "${TORCHRUN_ARGS[@]}" \
     -m cosmos_framework.scripts.train --sft-toml="$TOML_FILE" \
     -- "${TAIL_OVERRIDES[@]}"

--- a/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_libero_10_nano.sh
+++ b/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_libero_10_nano.sh
@@ -4,7 +4,7 @@
 
 # Complete recipe: LIBERO-10 action-policy SFT on Cosmos3-Nano (HSDP 2x8).
 # Run from this folder with the cosmos-framework venv active (see README):
-#   bash launch_sft_action_policy_libero.sh
+#   bash launch_sft_action_policy_libero_10_nano.sh
 # It prepares the small dependencies, checks for the staged libero_10 dataset, and trains.
 # Paths are fixed under this (git-ignored) folder, matching the reasoner finetune
 # wrappers, while the TOML and tail-overrides match the cosmos-framework example.
@@ -12,7 +12,7 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-TOML_FILE="toml/sft_config/action_policy_libero_repro.toml"
+TOML_FILE="toml/sft_config/action_policy_libero_10_nano.toml"
 : "${LIBERO_ROOT:=$PWD/data/LIBERO_LeRobot_v3/libero_10}"
 : "${BASE_CHECKPOINT_PATH:=$PWD/checkpoints/Cosmos3-Nano}"
 : "${WAN_VAE_PATH:=$PWD/checkpoints/wan22_vae/Wan2.2_VAE.pth}"

--- a/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_libero_all_nano.sh
+++ b/cookbooks/cosmos3/generator/action/finetune/launch_sft_action_policy_libero_all_nano.sh
@@ -4,7 +4,7 @@
 
 # Complete recipe: LIBERO-all (4-suite) action-policy SFT on Cosmos3-Nano (HSDP 2x8).
 # Run from this folder with the cosmos-framework venv active (see README):
-#   bash launch_sft_action_policy_libero_all.sh
+#   bash launch_sft_action_policy_libero_all_nano.sh
 # Trains on all 4 LIBERO suites (equal mix); it prepares the small dependencies,
 # checks for the staged suites, and trains. The 4-suite mix needs longer training
 # than libero_10-only (max_iter 5000 vs 2000). Paths are fixed under this
@@ -13,7 +13,7 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-TOML_FILE="toml/sft_config/action_policy_libero_all_repro.toml"
+TOML_FILE="toml/sft_config/action_policy_libero_all_nano.toml"
 : "${LIBERO_ROOT:=$PWD/data/LIBERO_LeRobot_v3}"   # PARENT dir of the 4 suites
 : "${BASE_CHECKPOINT_PATH:=$PWD/checkpoints/Cosmos3-Nano}"
 : "${WAN_VAE_PATH:=$PWD/checkpoints/wan22_vae/Wan2.2_VAE.pth}"

--- a/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_droid_nano.toml
+++ b/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_droid_nano.toml
@@ -21,7 +21,7 @@ task         = "vfm"
 experiment   = "action_policy_droid_nano"
 project      = "cosmos3_action"
 group        = "action_sft"
-name         = "action_policy_droid_repro"
+name         = "action_policy_droid_nano"
 wandb_mode   = "online"
 
 [model]

--- a/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_libero_10_nano.toml
+++ b/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_libero_10_nano.toml
@@ -1,20 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: OpenMDW-1.1
 
-# LIBERO-all (4-suite) action-policy SFT run config for the
-# `action_policy_libero_all_nano` experiment. Trains on all 4 LIBERO suites
-# (equal mix); LIBERO_ROOT is the LIBERO_LeRobot_v3 PARENT dir. The 4-suite mix
-# is coverage-limited — it needs ~4500 iters to reach ~95% on libero_10 (vs the
-# libero_10-only recipe, which peaks by ~1500) — so max_iter is longer here.
+# LIBERO-10 action-policy SFT run config for the `action_policy_libero_nano`
+# experiment. Train on libero_10 alone (HSDP 2x8, global batch 2048).
 # Env: LIBERO_ROOT, BASE_CHECKPOINT_PATH, WAN_VAE_PATH, IMAGINAIRE_OUTPUT_ROOT.
 # See docs/action_policy_libero_sft.md.
 
 [job]
 task         = "vfm"
-experiment   = "action_policy_libero_all_nano"
+experiment   = "action_policy_libero_nano"
 project      = "cosmos3_action_libero"
 group        = "action_sft"
-name         = "action_policy_libero_all_repro"
+name         = "action_policy_libero_10_nano"
 wandb_mode   = "online"
 
 [model]
@@ -40,7 +37,7 @@ cycle_lengths = [16000]
 warm_up_steps = [500]
 
 [trainer]
-max_iter        = 5000
+max_iter        = 2000
 logging_iter    = 50
 grad_accum_iter = 1       # global batch = max_samples 128 x (shard 8 x replicate 2) x 1 = 2048
 

--- a/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_libero_all_nano.toml
+++ b/cookbooks/cosmos3/generator/action/finetune/toml/sft_config/action_policy_libero_all_nano.toml
@@ -1,17 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: OpenMDW-1.1
 
-# LIBERO-10 action-policy SFT run config for the `action_policy_libero_nano`
-# experiment. Train on libero_10 alone (HSDP 2x8, global batch 2048).
+# LIBERO-all (4-suite) action-policy SFT run config for the
+# `action_policy_libero_all_nano` experiment. Trains on all 4 LIBERO suites
+# (equal mix); LIBERO_ROOT is the LIBERO_LeRobot_v3 PARENT dir. The 4-suite mix
+# is coverage-limited — it needs ~4500 iters to reach ~95% on libero_10 (vs the
+# libero_10-only recipe, which peaks by ~1500) — so max_iter is longer here.
 # Env: LIBERO_ROOT, BASE_CHECKPOINT_PATH, WAN_VAE_PATH, IMAGINAIRE_OUTPUT_ROOT.
 # See docs/action_policy_libero_sft.md.
 
 [job]
 task         = "vfm"
-experiment   = "action_policy_libero_nano"
+experiment   = "action_policy_libero_all_nano"
 project      = "cosmos3_action_libero"
 group        = "action_sft"
-name         = "action_policy_libero_repro"
+name         = "action_policy_libero_all_nano"
 wandb_mode   = "online"
 
 [model]
@@ -37,7 +40,7 @@ cycle_lengths = [16000]
 warm_up_steps = [500]
 
 [trainer]
-max_iter        = 2000
+max_iter        = 5000
 logging_iter    = 50
 grad_accum_iter = 1       # global batch = max_samples 128 x (shard 8 x replicate 2) x 1 = 2048
 

--- a/cookbooks/cosmos3/generator/action/run_fd_with_cosmos_framework.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_fd_with_cosmos_framework.ipynb
@@ -14,22 +14,24 @@
    "id": "fd-title",
    "metadata": {},
    "source": [
-    "# Cosmos3 Nano Action Forward Dynamics with Cosmos Framework\n",
+    "# Cosmos3 Action Forward Dynamics with Cosmos Framework\n",
     "\n",
-    "This notebook runs Cosmos3 Nano **action forward-dynamics** inference through the native Cosmos Framework PyTorch entrypoint:\n",
+    "This notebook runs Cosmos3 **action forward-dynamics** inference through the native Cosmos Framework PyTorch entrypoint:\n",
     "\n",
     "```bash\n",
     "python -m cosmos_framework.scripts.inference\n",
     "```\n",
     "\n",
-    "Forward dynamics predicts future visual observations from an initial image and an action trajectory. This notebook is written as a first-run cookbook: clone or locate the framework source, install dependencies from scratch, verify the GPU environment, build AV, robotics, and UMI input specs, run Nano inference, and visualize generated videos.\n",
+    "Forward dynamics predicts future visual observations from an initial image and an action trajectory. This notebook is written as a first-run cookbook: clone or locate the framework source, install dependencies from scratch, verify the GPU environment, build AV, robotics, and UMI input specs, run inference, and visualize generated videos.\n",
     "\n",
     "Tested path from the audit:\n",
     "\n",
     "- Framework checkout: `packages/cosmos3`\n",
     "- Install command: `uv sync --all-extras --group=cu130-train`\n",
     "- Backend: Cosmos Framework / `cosmos_framework.scripts.inference`\n",
-    "- Model: `Cosmos3-Nano`\n"
+    "- Models: `Cosmos3-Nano` (default), `Cosmos3-Edge`, and `Cosmos3-Super`\n",
+    "\n",
+    "Every inference cell below reads the checkpoint from `COSMOS3_CHECKPOINT_PATH` (set in step 2, default `Cosmos3-Nano`). To run the same forward-dynamics examples on Edge instead, set `COSMOS3_CHECKPOINT_PATH=Cosmos3-Edge` or `Cosmos3-Super` before the configuration cell — nothing else changes.\n"
    ]
   },
   {
@@ -78,9 +80,12 @@
     "export COSMOS3_GIT_URL=https://github.com/NVIDIA/cosmos-framework.git\n",
     "export COSMOS3_UV_GROUP=cu130-train  # CUDA 13 driver; use cu128-train for a CUDA 12.x driver\n",
     "export COSMOS3_OUTPUT_ROOT=/path/to/action/outputs\n",
+    "export COSMOS3_CHECKPOINT_PATH=Cosmos3-Edge  # optional: Cosmos3-Edge or Cosmos3-Super; defaults to Cosmos3-Nano\n",
     "export HF_HOME=/path/to/large/huggingface/cache\n",
     "export CUDA_VISIBLE_DEVICES=0\n",
     "```\n",
+    "\n",
+    "`COSMOS3_CHECKPOINT_PATH` selects the model for every inference cell below; leave it unset to use `Cosmos3-Nano`, or set it to `Cosmos3-Edge` or `Cosmos3-Super` to run the same examples on those models.\n",
     "\n",
     "For SSH access, set `COSMOS3_GIT_URL=git@github.com:NVIDIA/cosmos-framework.git`.\n"
    ]

--- a/cookbooks/cosmos3/generator/action/run_fd_with_vllm_omni.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_fd_with_vllm_omni.ipynb
@@ -13,7 +13,7 @@
    "id": "fdvl-title",
    "metadata": {},
    "source": [
-    "# Cosmos3 Nano Action: Forward Dynamics with vLLM-Omni\n",
+    "# Cosmos3 Action: Forward Dynamics with vLLM-Omni\n",
     "\n",
     "## Prerequisites\n",
     "\n",
@@ -21,15 +21,25 @@
     "\n",
     "## Overview\n",
     "\n",
-    "This notebook runs Cosmos3 Nano **action forward-dynamics** inference through the vLLM-Omni OpenAI-compatible video API:\n",
+    "This notebook runs Cosmos3 **action forward-dynamics** inference through the vLLM-Omni OpenAI-compatible video API:\n",
     "\n",
     "```text\n",
     "POST /v1/videos\n",
     "```\n",
     "\n",
-    "Forward dynamics predicts future visual observations from an initial image and an action trajectory. This notebook contains separate AV and robotics sections that each build their own input spec, run inference, and visualize generated videos.\n",
+    "Forward dynamics predicts future visual observations from an initial image and an action trajectory. This notebook contains separate AV and robotics sections that each build their own input spec, run inference, and visualize generated videos.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4100dead",
+   "metadata": {},
+   "source": [
+    "## Start vLLM-Omni Server\n",
     "\n",
-    "Start the server in a terminal from the `cosmos` repo root. The container listens on port `8000`; Docker publishes it to host port `8001`, so the notebook uses `http://localhost:8001`.\n",
+    "Start one of the following servers in a terminal from the `cosmos` repo root. The commands are mutually exclusive: both use the same container name and publish the container's port `8000` to host port `8001`, which matches the notebook's default `http://localhost:8001` endpoint.\n",
+    "\n",
+    "### Cosmos3-Nano\n",
     "\n",
     "```bash\n",
     "docker rm -f cosmos3-vllm-omni-notebook 2>/dev/null || true\n",
@@ -48,9 +58,11 @@
     "    --port 8000 \\\n",
     "    --init-timeout 1800\n",
     "\n",
-    "# Wait until this returns model metadata before running the inference cell.\n",
+    "# Wait until this returns model metadata before running the inference cells.\n",
     "curl http://localhost:8001/v1/models\n",
-    "```\n"
+    "```\n",
+    "\n",
+    "The request cells below use the active Nano server endpoint. To keep outputs from separate model runs, set `COSMOS3_VLLM_OUTPUT_ROOT` to a different directory before running the configuration cell.\n"
    ]
   },
   {
@@ -114,7 +126,7 @@
    "source": [
     "## AV\n",
     "\n",
-    "In this example, we show how to provide a set of ego poses of a autonomous vehicle and an image to generate driving videos using Cosmos3-Nano.\n"
+    "In this example, we show how to provide a set of ego poses of a autonomous vehicle and an image to generate driving videos using the model served by the active vLLM-Omni endpoint.\n"
    ]
   },
   {
@@ -316,7 +328,7 @@
    "source": [
     "### Run AV Forward-Dynamics Inference\n",
     "\n",
-    "Runs `Cosmos3-Nano` on every line of the AV spec through vLLM-Omni. Each run writes its video to:\n",
+    "Runs the active Cosmos3 model on every line of the AV spec through vLLM-Omni. Each run writes its video to:\n",
     "\n",
     "```text\n",
     "<output>/action_forward_dynamics_av_custom/<name>/vision.mp4\n",
@@ -597,7 +609,7 @@
    "source": [
     "### Run Robotics Autoregressive Forward-Dynamics Inference\n",
     "\n",
-    "Runs `Cosmos3-Nano` once per robotics chunk through vLLM-Omni. Chunk 0 uses the DROID GT first frame. After each chunk finishes, the cell extracts that chunk's last generated frame and uses it as the conditioning image for the next chunk. Guardrails are disabled for this robotics run via `extra_params={\"guardrails\": false}`.\n",
+    "Runs the active Cosmos3 model once per robotics chunk through vLLM-Omni. Chunk 0 uses the DROID GT first frame. After each chunk finishes, the cell extracts that chunk's last generated frame and uses it as the conditioning image for the next chunk. Guardrails are disabled for this robotics run via `extra_params={\"guardrails\": false}`.\n",
     "\n",
     "Each request sets top-level `size` to the current conditioning image resolution so vLLM-Omni returns each autoregressive chunk without reflection padding.\n"
    ]

--- a/cookbooks/cosmos3/generator/action/run_id_with_cosmos_framework.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_id_with_cosmos_framework.ipynb
@@ -14,15 +14,15 @@
    "id": "id-title",
    "metadata": {},
    "source": [
-    "# Cosmos3 Nano Action Inverse Dynamics with Cosmos Framework\n",
+    "# Cosmos3 Action Inverse Dynamics with Cosmos Framework\n",
     "\n",
-    "This notebook runs Cosmos3 Nano **action inverse-dynamics** inference through the native Cosmos Framework PyTorch entrypoint:\n",
+    "This notebook runs Cosmos3 **action inverse-dynamics** inference through the native Cosmos Framework PyTorch entrypoint:\n",
     "\n",
     "```bash\n",
     "python -m cosmos_framework.scripts.inference\n",
     "```\n",
     "\n",
-    "Inverse dynamics is the reverse of forward dynamics: given a video, it predicts the ego-motion action trajectory that produced it. This notebook is written as a first-run cookbook: clone or locate the framework source, install dependencies from scratch, verify the GPU environment, build a custom AV input spec, run Nano inference, and visualize the predicted trajectory.\n",
+    "Inverse dynamics is the reverse of forward dynamics: given a video, it predicts the ego-motion action trajectory that produced it. This notebook is written as a first-run cookbook: clone or locate the framework source, install dependencies from scratch, verify the GPU environment, build a custom AV input spec, run inference, and visualize the predicted trajectory.\n",
     "\n",
     "See `run_fd_with_cosmos_framework.ipynb` for the forward-dynamics counterpart (image + trajectory -> video).\n",
     "\n",
@@ -31,7 +31,9 @@
     "- Framework checkout: `packages/cosmos3`\n",
     "- Install command: `uv sync --all-extras --group=cu130-train`\n",
     "- Backend: Cosmos Framework / `cosmos_framework.scripts.inference`\n",
-    "- Model: `Cosmos3-Nano`\n"
+    "- Models: `Cosmos3-Nano` (default), `Cosmos3-Edge`, and `Cosmos3-Super`\n",
+    "\n",
+    "Every inference cell below reads the checkpoint from `COSMOS3_CHECKPOINT_PATH` (set in step 2, default `Cosmos3-Nano`). To run the same inverse-dynamics examples on Edge instead, set `COSMOS3_CHECKPOINT_PATH=Cosmos3-Edge` or `Cosmos3-Super` before the configuration cell — nothing else changes.\n"
    ]
   },
   {
@@ -80,9 +82,12 @@
     "export COSMOS3_GIT_URL=https://github.com/NVIDIA/cosmos-framework.git\n",
     "export COSMOS3_UV_GROUP=cu130-train  # CUDA 13 driver; use cu128-train for a CUDA 12.x driver\n",
     "export COSMOS3_OUTPUT_ROOT=/path/to/action/outputs\n",
+    "export COSMOS3_CHECKPOINT_PATH=Cosmos3-Edge  # optional: Cosmos3-Edge or Cosmos3-Super; defaults to Cosmos3-Nano\n",
     "export HF_HOME=/path/to/large/huggingface/cache\n",
     "export CUDA_VISIBLE_DEVICES=0\n",
     "```\n",
+    "\n",
+    "`COSMOS3_CHECKPOINT_PATH` selects the model for every inference cell below; leave it unset to use `Cosmos3-Nano`, or set it to `Cosmos3-Edge` or `Cosmos3-Super` to run the same examples on those models.\n",
     "\n",
     "For SSH access, set `COSMOS3_GIT_URL=git@github.com:NVIDIA/cosmos-framework.git`.\n"
    ]

--- a/cookbooks/cosmos3/generator/action/run_id_with_vllm_omni.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_id_with_vllm_omni.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Cosmos3 Nano Action: Inverse Dynamics with vLLM-Omni\n",
+    "# Cosmos3 Action: Inverse Dynamics with vLLM-Omni\n",
     "\n",
     "## Prerequisites\n",
     "\n",
@@ -20,7 +20,7 @@
     "\n",
     "## Overview\n",
     "\n",
-    "This notebook runs Cosmos3 Nano **action inverse-dynamics** inference through the vLLM-Omni OpenAI-compatible video API:\n",
+    "This notebook runs Cosmos3 **action inverse-dynamics** inference through the vLLM-Omni OpenAI-compatible video API:\n",
     "\n",
     "```text\n",
     "POST /v1/videos\n",
@@ -35,7 +35,9 @@
    "source": [
     "## Start vLLM-Omni Server\n",
     "\n",
-    "Start the server in a terminal from the `cosmos` repo root. The container listens on port `8000`; Docker publishes it to host port `8001`, so the notebook uses `http://localhost:8001`.\n",
+    "Start one of the following servers in a terminal from the `cosmos` repo root. The commands are mutually exclusive: both use the same container name and publish the container's port `8000` to host port `8001`, which matches the notebook's default `http://localhost:8001` endpoint.\n",
+    "\n",
+    "### Cosmos3-Nano\n",
     "\n",
     "```bash\n",
     "docker rm -f cosmos3-vllm-omni-notebook 2>/dev/null || true\n",
@@ -54,9 +56,11 @@
     "    --port 8000 \\\n",
     "    --init-timeout 1800\n",
     "\n",
-    "# Wait until this returns model metadata before running the inference cell.\n",
+    "# Wait until this returns model metadata before running the inference cells.\n",
     "curl http://localhost:8001/v1/models\n",
-    "```\n"
+    "```\n",
+    "\n",
+    "The request cells below use the active Nano server endpoint. To keep outputs from separate model runs, set `COSMOS3_VLLM_OUTPUT_ROOT` to a different directory before running the configuration cell.\n"
    ]
   },
   {
@@ -211,7 +215,7 @@
    "source": [
     "## Run Inverse-Dynamics Inference\n",
     "\n",
-    "Runs `Cosmos3-Nano` on every line of the spec through vLLM-Omni. Inverse dynamics predicts an action, and this cell writes a PyTorch-compatible result file for each run:\n",
+    "Runs the active Cosmos3 model on every line of the spec through vLLM-Omni. Inverse dynamics predicts an action, and this cell writes a PyTorch-compatible result file for each run:\n",
     "\n",
     "```text\n",
     "<output>/<name>/sample_outputs.json\n",

--- a/cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md
+++ b/cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md
@@ -1,6 +1,10 @@
-# Cosmos3-Nano-Policy-DROID server
+# Cosmos3-Policy-DROID server
 
-Cosmos3-Nano-Policy-DROID is served by a policy **Server** that streams actions to a **Client** driving a simulated or real robot. This example uses [`RoboLab`](https://github.com/NVlabs/RoboLab), a simulation benchmark for task-generalist policies, as the client. Start the server first, then connect the client.
+Cosmos 3 offers two post-trained policy models for DROID:
+1. [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID)
+2. [Cosmos3-Edge-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Edge-Policy-DROID)
+
+Each of these policy models is served by a policy **Server** that streams actions to a **Client** driving a simulated or real robot. This example uses [`RoboLab`](https://github.com/NVlabs/RoboLab), a simulation benchmark for task-generalist policies, as the client. Start the server first, then connect the client.
 
 ## Table of Contents
 
@@ -56,10 +60,21 @@ The `--group=cu130-train` line targets a CUDA 13 driver (the default). On CUDA
 
 Inside the container, start the policy server:
 
-```
-python -m cosmos_framework.scripts.action_policy_server_robolab \
-  --port 8000
-```
+1. For [Cosmos3-Nano-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Nano-Policy-DROID), run:
+
+   ```
+   python -m cosmos_framework.scripts.action_policy_server_robolab \
+     --port 8000
+   ```
+
+2. For [Cosmos3-Edge-Policy-DROID](https://huggingface.co/nvidia/Cosmos3-Edge-Policy-DROID), run:
+
+   ```
+   python -m cosmos_framework.scripts.action_policy_server_robolab \
+     --checkpoint-path nvidia/Cosmos3-Edge-Policy-DROID \
+     --port 8000 \
+     --format-prompt-as-json True
+   ```
 
 ## Simulation Client
 

--- a/cookbooks/cosmos3/generator/audiovisual/README.md
+++ b/cookbooks/cosmos3/generator/audiovisual/README.md
@@ -1,8 +1,9 @@
 # Cosmos3 Generator Audiovisual Examples
 
 Generate images and video (with optional audio) from text or image prompts with
-`Cosmos3-Nano` and `Cosmos3-Super`, across Cosmos Framework, Diffusers,
-vLLM-Omni, and NIM backends. Sample prompts live under [`assets/`](./assets).
+`Cosmos3-Nano`, `Cosmos3-Super`, `Cosmos3-Edge`, and the published four-step
+distilled Cosmos3-Super students across Cosmos Framework, Diffusers, vLLM-Omni,
+and NIM backends. Sample prompts live under [`assets/`](./assets).
 
 > **NIM scope:** `Cosmos3-Generator` NIM currently exposes Text2Video and
 > Image2Video only. It does not expose text-to-image, video-to-video,
@@ -78,12 +79,24 @@ torchrun --nproc-per-node=1 \
 To run **Cosmos3-Super** instead, set `--checkpoint-path Cosmos3-Super` and use
 more GPUs via `--nproc-per-node`.
 
+To run **Cosmos3-Edge** instead, set `--checkpoint-path Cosmos3-Edge`. Edge has
+no audio modules, so keep `"enable_sound": False` in the payload.
+
 ### Notebook walkthrough
 
 [`run_with_cosmos_framework.ipynb`](./run_with_cosmos_framework.ipynb) is the full
 tutorial for the native PyTorch backend: it covers every use case — text-to-image,
 text-to-video, image-to-video, with audio on or off — and includes the detailed,
-environment-aware setup and visualization for each generation.
+environment-aware setup and visualization for each generation. It also includes
+four-GPU inference examples for `nvidia/Cosmos3-Super-Text2Image-4Step` and
+`nvidia/Cosmos3-Super-Image2Video-4Step`.
+
+### Distillation training recipe
+
+[`distill/README.md`](./distill/README.md) documents the short T2I and I2V DMD2
+training, resume, and student-only export workflow. The first supported topology
+is exactly 8 GB200 nodes with 4 GPUs per node. This is an integration smoke
+recipe, not a production reproduction recipe.
 
 ## Run with Diffusers
 

--- a/cookbooks/cosmos3/generator/audiovisual/distill/README.md
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/README.md
@@ -1,0 +1,221 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: OpenMDW-1.1 -->
+
+# Cosmos3 Generator Distillation
+
+This cookbook demonstrates short DMD2 distillation smoke runs for the released
+Cosmos3-Super Text2Image and Image2Video models with Cosmos Framework.
+
+> This is a functional training recipe, not a production reproduction recipe.
+> It uses a small public dataset and six optimizer iterations to validate model
+> loading, loss and gradient computation, checkpoint resume, student-only
+> export, and inference. It does not promise production-quality samples or
+> reproduction of NVIDIA training results.
+
+## Supported recipes
+
+| Launcher | TOML | Teacher | Initial student | Data view |
+| --- | --- | --- | --- | --- |
+| `launch_distillation_t2i.sh` | `toml/distillation_t2i.toml` | [`nvidia/Cosmos3-Super-Text2Image`](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image) | [`nvidia/Cosmos3-Super-Text2Image-4Step`](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image-4Step) | One 768-class frame per BridgeData2 video, no visual conditioning |
+| `launch_distillation_i2v.sh` | `toml/distillation_i2v.toml` | [`nvidia/Cosmos3-Super-Image2Video`](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video) | [`nvidia/Cosmos3-Super-Image2Video-4Step`](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video-4Step) | 61 frames at 480p, first-frame conditioning |
+
+Both use
+[`nvidia/BridgeData2-Subset-Synthetic-Captions`](https://huggingface.co/datasets/nvidia/BridgeData2-Subset-Synthetic-Captions).
+The fake-score network has the same 32B architecture and is initialized from
+the teacher by the existing DMD2 training path.
+
+## Prerequisites
+
+1. Follow the shared [Cosmos Framework environment setup](../../../README.md#cosmos-framework).
+   Activate the resulting training environment before launching.
+2. Accept the licenses for the four model repositories and BridgeData2, then
+   authenticate with `uvx hf@latest auth login` or set `HF_TOKEN`.
+3. Allocate **8 GB200 nodes with 4 GPUs per node** for the provided canonical
+   profile. A 4-node x 4-GPU GB200 profile has also completed end-to-end
+   validation; see [Validated topology scope](#validated-topology-scope) for
+   the coordinated configuration changes it requires.
+4. Choose a high-capacity shared filesystem path visible at the same location
+   on every node. The launchers store the dataset, Hugging Face materialization,
+   converted DCP checkpoints, training state, and exports beneath it.
+5. Invoke the same launcher once on every allocated node. Your scheduler is
+   responsible for assigning `NODE_RANK` and starting one launcher process per
+   node.
+
+The launchers never upload weights, checkpoints, or outputs to Hugging Face.
+
+## Topology variables
+
+Each node must receive these values:
+
+| Variable | Provided canonical profile |
+| --- | --- |
+| `DISTILL_ROOT` | Shared writable directory |
+| `NNODES` | `8` |
+| `NPROC_PER_NODE` | `4` |
+| `NODE_RANK` | Unique integer from `0` through `7` |
+| `MASTER_ADDR` | Host name or IP of node rank 0 |
+| `MASTER_PORT` | One free TCP port, identical on every node |
+
+The scripts use standard multi-node `torchrun`; they do not contain Slurm,
+Kubernetes, or another scheduler-specific submission layer.
+
+### Validated topology scope
+
+Both T2I and I2V have completed short training, iteration-5 checkpoint save,
+strict resume through iteration 6, student-only export, and inference on these
+GB200 profiles:
+
+| Profile | GPUs | FSDP data-parallel shard degree | Cookbook status |
+| --- | ---: | ---: | --- |
+| 8 nodes x 4 GPUs | 32 | 32 | Provided canonical profile |
+| 4 nodes x 4 GPUs | 16 | 16 | Validated custom profile |
+
+The checked-in launchers and TOMLs remain pinned to the canonical 8-node
+profile; a separate 4-node TOML is intentionally not shipped. To use the
+validated 4-node profile, make these coordinated local changes:
+
+1. Set `NNODES=4`, keep `NPROC_PER_NODE=4`, and assign `NODE_RANK` from `0`
+   through `3`.
+2. Update the topology validation in `distill/common.sh` to accept 4 nodes.
+3. Set `model.parallelism.data_parallel_shard_degree=16` in the selected T2I
+   or I2V TOML.
+
+The 16-node x 4-GPU profile and other topology or parallelism combinations
+have not been validated by this cookbook.
+
+## Training configuration
+
+The two TOML files are the user-facing training configuration. They expose the
+mode-specific data view, four-step sampling schedule, DMD2 loss settings,
+student and fake-score optimizer settings, strict checkpoint policy, and the
+provided canonical 32-GPU parallelism shape. The validated 16-GPU custom
+profile uses the coordinated changes described above.
+
+`build_distillation_config.py` strictly validates the selected TOML and
+constructs framework objects that TOML cannot represent directly, including
+`DMD2RFModel`, `DistillationTrainer`, the two-optimizer LazyDict, the nested
+BridgeData2 dataloader, callbacks, and the distillation checkpointer. The
+launchers supply the runtime dataset and converted teacher/student DCP paths,
+then serialize and round-trip validate the resulting Cosmos Framework YAML.
+Unknown TOML keys are rejected instead of being silently ignored.
+
+## Launch T2I
+
+Run the following on every node after the scheduler fills in `NODE_RANK`:
+
+```bash
+cd cookbooks/cosmos3/generator/audiovisual
+
+export DISTILL_ROOT=/shared/path/cosmos3-distillation
+export NNODES=8
+export NPROC_PER_NODE=4
+export NODE_RANK=<0-through-7>
+export MASTER_ADDR=<rank-0-hostname>
+export MASTER_PORT=29500
+
+bash distill/launch_distillation_t2i.sh
+```
+
+## Launch I2V
+
+Use a different free rendezvous port if T2I is still running:
+
+```bash
+cd cookbooks/cosmos3/generator/audiovisual
+
+export DISTILL_ROOT=/shared/path/cosmos3-distillation
+export NNODES=8
+export NPROC_PER_NODE=4
+export NODE_RANK=<0-through-7>
+export MASTER_ADDR=<rank-0-hostname>
+export MASTER_PORT=29501
+
+bash distill/launch_distillation_i2v.sh
+```
+
+Use `DRY_RUN=1` to print asset-preparation, training, resume, and export commands
+without downloading models or starting GPU work:
+
+```bash
+DRY_RUN=1 bash distill/launch_distillation_t2i.sh
+```
+
+## What each launcher does
+
+Node rank 0 prepares shared assets while the other nodes wait for completed
+files. Existing validated files are reused.
+
+1. Download the pinned BridgeData2 dataset revision and Wan2.2 VAE.
+2. Materialize the selected full teacher and four-step student from Hugging
+   Face and convert both to DCP.
+3. Load the selected TOML and round-trip validate the generated Cosmos
+   Framework YAML.
+4. Start a 32-rank training process with `--no-resume`, train through iteration
+   5, and write `iter_000000005`.
+5. Start a new 32-rank process with `--resume` and train from iteration 5 through
+   iteration 6. Because iteration 6 is not a `save_iter` multiple, the trainer's
+   terminal-checkpoint behavior writes `iter_000000006` before shutdown.
+6. On node rank 0, export the iteration-6 student without teacher or fake-score
+   weights. Set `EXPORT_AFTER_TRAIN=0` to skip this local export.
+
+The DMD2 settings intentionally follow the validated four-step shape: backward
+SDE simulation with timesteps `[1.0, 15/16, 5/6, 5/8]`, teacher guidance 6.0,
+student update frequency 5, VSD mean reduction, fake-score active-mean
+reduction, and gradient clipping. The public dataset and short duration are
+deliberate smoke-test deviations from production training.
+
+## Outputs
+
+For T2I, the key paths are:
+
+```text
+$DISTILL_ROOT/
+|-- configs/distillation_t2i.yaml
+|-- checkpoints/t2i/teacher.dcp/model/
+|-- checkpoints/t2i/student.dcp/model/
+`-- outputs/
+    |-- train/cosmos3/distillation/cosmos3_super_t2i_dmd2_smoke/checkpoints/
+    `-- invocations/t2i/cosmos3_super_t2i_dmd2_smoke/
+        |-- config.yaml
+        |-- job -> $DISTILL_ROOT/outputs/train/cosmos3/distillation/cosmos3_super_t2i_dmd2_smoke
+        `-- student/
+```
+
+Replace `t2i` with `i2v` for the I2V run. DCP checkpoints include model,
+optimizer, scheduler, trainer, and dataloader state so the second process tests
+a real training resume rather than only loading model weights.
+
+## Inference with the published four-step students
+
+The audiovisual
+[`run_with_cosmos_framework.ipynb`](../run_with_cosmos_framework.ipynb)
+contains the published distilled T2I and I2V inference examples, including
+payload creation, four-GPU model sharding, the fixed-step sampling arguments,
+and artifact display. These are functional smoke examples, not
+production-quality reproduction claims.
+
+## Troubleshooting
+
+- **Topology validation fails:** the checked-in launchers intentionally accept
+  only the provided 8-node x 4-GPU profile. The 4-node x 4-GPU profile is also
+  validated, but requires the three coordinated local changes in
+  [Validated topology scope](#validated-topology-scope). The 16-node x 4-GPU
+  profile and other configurations remain unvalidated.
+- **Nodes time out waiting for assets or the generated config:** node rank 0
+  performs the downloads, checkpoint conversion, and config generation while
+  the other nodes wait for files under `DISTILL_ROOT`. Confirm that every node
+  sees the same shared path, then inspect the rank-0 process for the original
+  failure. `ASSET_WAIT_TIMEOUT_SECONDS` defaults to 7200 seconds.
+- **Hugging Face 401/403 on node rank 0:** accept the licenses for gated model
+  and dataset repositories, and confirm that rank 0 can access the teacher,
+  student, BridgeData2, and Wan VAE repositories with its `HF_TOKEN` or saved
+  Hugging Face login.
+- **Python, CUDA, or libtorch mismatch:** confirm that `PYTHON_BIN` and
+  `TORCHRUN_BIN` resolve to the same activated Cosmos Framework environment.
+  The launchers already clear `LD_LIBRARY_PATH`; no extra manual clearing is
+  required.
+- **Out of memory after changing the recipe:** both documented profiles were
+  validated on GB200, while the checked-in TOMLs provide the 8-node x 4-GPU
+  profile. Changes to GPU count, hardware, resolution, sequence length, batch
+  size, or parallelism outside those profiles may require coordinated retuning
+  and separate validation.

--- a/cookbooks/cosmos3/generator/audiovisual/distill/build_distillation_config.py
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/build_distillation_config.py
@@ -1,0 +1,454 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+"""Build short Cosmos3-Super DMD2 distillation configs from public APIs."""
+
+import argparse
+import copy
+from pathlib import Path
+from typing import Literal
+
+import tomllib
+from pydantic import BaseModel, ConfigDict
+
+from cosmos_framework.callbacks.dmd2_metrics import DMD2Metrics
+from cosmos_framework.callbacks.grad_clip_distillation import GradClip
+from cosmos_framework.callbacks.iter_speed import IterSpeed
+from cosmos_framework.callbacks.manual_gc import ManualGarbageCollection
+from cosmos_framework.callbacks.skip_nan_step import SkipNaNStep
+from cosmos_framework.callbacks.wandb_log import WandbCallback
+from cosmos_framework.checkpoint.dcp_distill import DistributedCheckpointer
+from cosmos_framework.configs.base.config import make_config
+from cosmos_framework.configs.base.defaults.tokenizer import Wan2pt2VAEConfig
+from cosmos_framework.configs.base.experiment.distillation.dmd2_config import (
+    DMD2OptimizerConfig,
+    DMD2RFConfig,
+)
+from cosmos_framework.configs.base.experiment.sft.models.super_model_config import (
+    SUPER_MODEL_CONFIG,
+)
+from cosmos_framework.data.generator.joint_dataloader import (
+    PackingDataLoader,
+    RankPartitionedDataLoader,
+)
+from cosmos_framework.data.generator.local_datasets.sft_dataset import get_sft_dataset
+from cosmos_framework.inference.common.config import (
+    deserialize_config,
+    serialize_config,
+    structure_config,
+)
+from cosmos_framework.model.generator.distillation.dmd2_rf import DMD2RFModel
+from cosmos_framework.model.generator.reasoner.qwen3_vl import (
+    configs as qwen3_vl_configs,
+)
+from cosmos_framework.trainer.distillation import DistillationTrainer
+from cosmos_framework.utils.callback import LowPrecisionCallback
+from cosmos_framework.utils.config import CheckpointConfig, Config
+from cosmos_framework.utils.generator.optimizer import build_lr_scheduler
+from cosmos_framework.utils.lazy_config import PLACEHOLDER, LazyDict
+from cosmos_framework.utils.lazy_config import LazyCall as L
+
+Mode = Literal["t2i", "i2v"]
+
+_RECIPE_MODEL_CONFIG = ConfigDict(extra="forbid")
+_QWEN3_VL_CONFIG_PACKAGE_FILE = qwen3_vl_configs.__file__
+assert _QWEN3_VL_CONFIG_PACKAGE_FILE is not None
+_QWEN3_VL_32B_CONFIG = Path(_QWEN3_VL_CONFIG_PACKAGE_FILE).with_name(
+    "Qwen3-VL-32B-Instruct.json"
+)
+
+
+class JobRecipeConfig(BaseModel):
+    """User-facing run identity."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    project: str
+    group: str
+    name: str
+    wandb_mode: str
+
+
+class ParallelismRecipeConfig(BaseModel):
+    """The canonical 32-GPU training topology."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    data_parallel_shard_degree: int
+    context_parallel_shard_degree: int
+
+
+class FixedStepSamplerRecipeConfig(BaseModel):
+    """Four-step student sampling schedule."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    sample_type: str
+    t_list: list[float]
+
+
+class ModelRecipeConfig(BaseModel):
+    """DMD2 model and loss knobs exposed by the cookbook."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    resolution: str
+    max_num_tokens_after_packing: int
+    lora_enabled: bool
+    ema_enabled: bool
+    compile_enabled: bool
+    base_fps: int
+    rectified_flow_shift: dict[str, int]
+    rectified_flow_loss_scale: float
+    train_time_video_distribution: str
+    simulation_mode: str
+    teacher_guidance: float
+    student_update_freq: int
+    vsd_loss_reduction: str
+    fake_score_loss_reduction: str
+    warmup_student_steps: int
+    warmup_critic_steps: int
+    grad_clip: bool
+    parallelism: ParallelismRecipeConfig
+    fixed_step_sampler: FixedStepSamplerRecipeConfig
+
+
+class OptimizerGroupRecipeConfig(BaseModel):
+    """One DMD2 optimizer parameter group."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    lr: float
+    betas: list[float]
+
+
+class OptimizerRecipeConfig(BaseModel):
+    """Student and fake-score optimizer settings."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    net: OptimizerGroupRecipeConfig
+    fake_score: OptimizerGroupRecipeConfig
+
+
+class TrainerRecipeConfig(BaseModel):
+    """Short smoke-run trainer settings."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    distributed_parallelism: str
+    grad_accum_iter: int
+    logging_iter: int
+    max_iter: int
+    seed: int
+    recompile_limit: int
+
+
+class CheckpointRecipeConfig(BaseModel):
+    """Strict DCP save and resume settings."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    save_iter: int
+    strict_resume: bool
+
+
+class DataloaderTrainRecipeConfig(BaseModel):
+    """Mode-specific BridgeData2 data view."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    num_video_frames: int
+    conditioning_config: dict[int, float] | None = None
+    append_duration_fps_timestamps: bool
+    conditioning_fps_noise_std: float
+    max_caption_tokens: int
+    max_samples_per_batch: int
+    batch_size: int
+    num_workers: int
+    prefetch_factor: int
+
+
+class DistillationRecipeConfig(BaseModel):
+    """Validated TOML surface for one cookbook mode."""
+
+    model_config = _RECIPE_MODEL_CONFIG
+
+    mode: Mode
+    job: JobRecipeConfig
+    model: ModelRecipeConfig
+    optimizer: OptimizerRecipeConfig
+    trainer: TrainerRecipeConfig
+    checkpoint: CheckpointRecipeConfig
+    dataloader_train: DataloaderTrainRecipeConfig
+
+
+def load_recipe(recipe_path: Path) -> DistillationRecipeConfig:
+    """Load and strictly validate one distillation TOML recipe."""
+    with recipe_path.open("rb") as recipe_file:
+        return DistillationRecipeConfig.model_validate(tomllib.load(recipe_file))
+
+
+def _build_model_config(
+    *,
+    recipe: DistillationRecipeConfig,
+    teacher_checkpoint: Path,
+    student_checkpoint: Path,
+) -> DMD2RFConfig:
+    model_config = structure_config(copy.deepcopy(SUPER_MODEL_CONFIG), DMD2RFConfig)
+
+    model_config.resolution = recipe.model.resolution
+    model_config.max_num_tokens_after_packing = (
+        recipe.model.max_num_tokens_after_packing
+    )
+    model_config.lora_enabled = recipe.model.lora_enabled
+    model_config.ema.enabled = recipe.model.ema_enabled
+    model_config.parallelism.data_parallel_shard_degree = (
+        recipe.model.parallelism.data_parallel_shard_degree
+    )
+    model_config.parallelism.context_parallel_shard_degree = (
+        recipe.model.parallelism.context_parallel_shard_degree
+    )
+    model_config.compile.enabled = recipe.model.compile_enabled
+    tokenizer_config = copy.deepcopy(Wan2pt2VAEConfig)
+    tokenizer_config.update(model_config.tokenizer)
+    model_config.tokenizer = tokenizer_config
+    model_config.tokenizer.vae_path = "${oc.env:WAN_VAE_PATH}"
+    model_config.tokenizer.encode_chunk_frames = {
+        "256": 68,
+        "480": 24,
+        "720": 12,
+        "768": 12,
+    }
+    model_config.tokenizer.encode_exact_durations = None
+    model_config.vlm_config.pretrained_weights.credentials_path = ""
+    model_config.vlm_config.pretrained_weights.enable_gcs_patch_in_boto3 = False
+
+    model_config.diffusion_expert_config.base_fps = recipe.model.base_fps
+    model_config.rectified_flow_training_config.shift = dict(
+        recipe.model.rectified_flow_shift
+    )
+    model_config.rectified_flow_training_config.loss_scale = (
+        recipe.model.rectified_flow_loss_scale
+    )
+    model_config.rectified_flow_training_config.train_time_video_distribution = (
+        recipe.model.train_time_video_distribution
+    )
+
+    model_config.vlm_config.model_instance["config"]["base_config"]["json_file"] = str(
+        _QWEN3_VL_32B_CONFIG
+    )
+    model_config.teacher_load_from = LazyDict(
+        {"load_path": str(teacher_checkpoint), "credentials": ""},
+        flags={"allow_objects": True},
+    )
+    model_config.student_load_from = LazyDict(
+        {"load_path": str(student_checkpoint), "credentials": ""},
+        flags={"allow_objects": True},
+    )
+    model_config.load_teacher_weights = True
+    model_config.vlm_config_teacher = copy.deepcopy(model_config.vlm_config)
+    model_config.vlm_config_fake_score = copy.deepcopy(model_config.vlm_config)
+    model_config.fixed_step_sampler_config.t_list = list(
+        recipe.model.fixed_step_sampler.t_list
+    )
+    model_config.fixed_step_sampler_config.sample_type = (
+        recipe.model.fixed_step_sampler.sample_type
+    )
+    model_config.simulation_mode = recipe.model.simulation_mode
+    model_config.teacher_guidance = recipe.model.teacher_guidance
+    model_config.student_update_freq = recipe.model.student_update_freq
+    model_config.vsd_loss_reduction = recipe.model.vsd_loss_reduction
+    model_config.fake_score_loss_reduction = recipe.model.fake_score_loss_reduction
+    model_config.warmup_student_steps = recipe.model.warmup_student_steps
+    model_config.warmup_critic_steps = recipe.model.warmup_critic_steps
+    model_config.grad_clip = recipe.model.grad_clip
+    return model_config
+
+
+def _build_optimizer(recipe: DistillationRecipeConfig) -> LazyDict:
+    optimizer = DMD2OptimizerConfig()
+    optimizer.net.lr = recipe.optimizer.net.lr
+    optimizer.net.betas = list(recipe.optimizer.net.betas)
+    optimizer.fake_score.lr = recipe.optimizer.fake_score.lr
+    optimizer.fake_score.betas = list(recipe.optimizer.fake_score.betas)
+    return LazyDict(
+        {"net": optimizer.net, "fake_score": optimizer.fake_score},
+        flags={"allow_objects": True},
+    )
+
+
+def _build_dataloader(
+    *, recipe: DistillationRecipeConfig, dataset_path: Path
+) -> LazyDict:
+    return L(PackingDataLoader)(
+        audio_sample_rate=48_000,
+        dataset_name=f"bridge_data2_{recipe.mode}",
+        max_samples_per_batch=recipe.dataloader_train.max_samples_per_batch,
+        max_sequence_length=None,
+        patch_spatial=2,
+        sound_latent_fps=0,
+        tokenizer_spatial_compression_factor=16,
+        tokenizer_temporal_compression_factor=4,
+        dataloader=L(RankPartitionedDataLoader)(
+            batch_size=recipe.dataloader_train.batch_size,
+            datasets={
+                "video": {
+                    "ratio": 1,
+                    "dataset": L(get_sft_dataset)(
+                        append_duration_fps_timestamps=(
+                            recipe.dataloader_train.append_duration_fps_timestamps
+                        ),
+                        append_resolution_info=True,
+                        caption_suffix="",
+                        cfg_dropout_keep_metadata=False,
+                        cfg_dropout_rate=0.1,
+                        conditioning_config=recipe.dataloader_train.conditioning_config,
+                        conditioning_fps=-1,
+                        conditioning_fps_noise_std=(
+                            recipe.dataloader_train.conditioning_fps_noise_std
+                        ),
+                        frame_selection_mode="first",
+                        jsonl_paths=[
+                            str(dataset_path / "train/video_dataset_file.jsonl")
+                        ],
+                        max_caption_tokens=recipe.dataloader_train.max_caption_tokens,
+                        min_short_edge=0,
+                        num_video_frames=recipe.dataloader_train.num_video_frames,
+                        resolution=recipe.model.resolution,
+                        sample_by_window=False,
+                        temporal_compression_factor=4,
+                        temporal_interval_mode="max_30fps",
+                        tokenizer_config="${model.config.vlm_config.tokenizer}",
+                        use_system_prompt=False,
+                    ),
+                }
+            },
+            in_order=True,
+            num_workers=recipe.dataloader_train.num_workers,
+            persistent_workers=True,
+            pin_memory=True,
+            prefetch_factor=recipe.dataloader_train.prefetch_factor,
+            sampler=None,
+        ),
+    )
+
+
+def build_config(
+    *,
+    recipe_path: Path,
+    dataset_path: Path,
+    teacher_checkpoint: Path,
+    student_checkpoint: Path,
+) -> Config:
+    """Build one mode-specific config for the two-phase distillation smoke workflow."""
+    recipe = load_recipe(recipe_path)
+    model_config = _build_model_config(
+        recipe=recipe,
+        teacher_checkpoint=teacher_checkpoint,
+        student_checkpoint=student_checkpoint,
+    )
+
+    config = make_config()
+    config.job.project = recipe.job.project
+    config.job.group = recipe.job.group
+    config.job.name = recipe.job.name
+    config.job.wandb_mode = recipe.job.wandb_mode
+
+    config.model = L(DMD2RFModel)(config=model_config, _recursive_=False)
+    config.optimizer = _build_optimizer(recipe)
+    config.scheduler = L(build_lr_scheduler)(
+        optimizer=PLACEHOLDER,
+        lr_scheduler_type="LambdaLinear",
+        warm_up_steps=[0],
+        cycle_lengths=[10_000_000_000_000],
+        f_start=[1.0],
+        f_max=[1.0],
+        f_min=[1.0],
+    )
+    config.dataloader_train = _build_dataloader(
+        recipe=recipe, dataset_path=dataset_path
+    )
+    config.dataloader_val = None
+
+    config.trainer.type = DistillationTrainer
+    config.trainer.distributed_parallelism = recipe.trainer.distributed_parallelism
+    config.trainer.grad_accum_iter = recipe.trainer.grad_accum_iter
+    config.trainer.logging_iter = recipe.trainer.logging_iter
+    config.trainer.max_iter = recipe.trainer.max_iter
+    config.trainer.run_validation = False
+    config.trainer.run_validation_on_start = False
+    config.trainer.save_zero_checkpoint = False
+    config.trainer.seed = recipe.trainer.seed
+    config.trainer.straggler_detection.enabled = False
+    config.trainer.compile_config.recompile_limit = recipe.trainer.recompile_limit
+    config.trainer.callbacks = LazyDict(
+        {
+            "dmd2_metrics": L(DMD2Metrics)(output_path=""),
+            "grad_clip": L(GradClip)(clip_norm=1.0),
+            "iter_speed": L(IterSpeed)(
+                every_n=1, save_s3=False, save_s3_every_log_n=500, hit_thres=200
+            ),
+            "low_precision": L(LowPrecisionCallback)(
+                update_iter=1, config=None, trainer=None
+            ),
+            "manual_gc": L(ManualGarbageCollection)(every_n=5),
+            "skip_nan_step": L(SkipNaNStep)(max_consecutive_nan=100),
+            "wandb": L(WandbCallback)(
+                logging_iter_multipler=1,
+                save_logging_iter_multipler=10,
+                save_s3=False,
+            ),
+        },
+        flags={"allow_objects": True},
+    )
+
+    config.checkpoint = CheckpointConfig(
+        type=L(DistributedCheckpointer)(),
+        dcp_async_mode_enabled=False,
+        dcp_load_dedup=True,
+        save_iter=recipe.checkpoint.save_iter,
+        strict_resume=recipe.checkpoint.strict_resume,
+        load_path="",
+        load_training_state=False,
+        broadcast_via_filesystem=True,
+    )
+    config.checkpoint.hf_export.enabled = False
+    config.upload_reproducible_setup = False
+    return config
+
+
+def write_config(config: Config, output_path: Path) -> None:
+    """Serialize a training config and verify that Cosmos Framework can read it."""
+    serialize_config(config, output_path)
+    deserialize_config(output_path)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--recipe-toml", type=Path, required=True)
+    parser.add_argument("--dataset-path", type=Path, required=True)
+    parser.add_argument("--teacher-checkpoint", type=Path, required=True)
+    parser.add_argument("--student-checkpoint", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--validate-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Build, serialize, and round-trip validate one cookbook config."""
+    args = _parse_args()
+    config = build_config(
+        recipe_path=args.recipe_toml,
+        dataset_path=args.dataset_path,
+        teacher_checkpoint=args.teacher_checkpoint,
+        student_checkpoint=args.student_checkpoint,
+    )
+    write_config(config, args.output)
+    if args.validate_only:
+        recipe = load_recipe(args.recipe_toml)
+        print(f"Validated {recipe.mode} distillation config: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cookbooks/cosmos3/generator/audiovisual/distill/common.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/common.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# Shared implementation for the T2I and I2V distillation launchers.
+
+set -euo pipefail
+
+DISTILL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BRIDGE_DATA2_REVISION="40d018ac1c1a2a4b9734f17fdb21f3d933c49a01"
+
+
+print_command() {
+    printf "+"
+    printf " %q" "$@"
+    printf "\n"
+}
+
+
+run_command() {
+    if [[ "${DRY_RUN}" == "1" ]]; then
+        print_command "$@"
+    else
+        "$@"
+    fi
+}
+
+
+wait_for_file() {
+    local path="$1"
+    local description="$2"
+    local waited=0
+    local timeout="${ASSET_WAIT_TIMEOUT_SECONDS:-7200}"
+
+    while [[ ! -f "${path}" ]]; do
+        if (( waited >= timeout )); then
+            echo "Timed out waiting for ${description}: ${path}" >&2
+            return 1
+        fi
+        sleep 10
+        waited=$((waited + 10))
+    done
+}
+
+
+validate_launch_environment() {
+    : "${DISTILL_ROOT:?Set DISTILL_ROOT to a shared filesystem path visible from all eight nodes}"
+    : "${MASTER_ADDR:?Set MASTER_ADDR to the rank-0 host name or IP address}"
+    : "${MASTER_PORT:?Set MASTER_PORT to a free rendezvous port}"
+    : "${NODE_RANK:?Set NODE_RANK to the rank of this node from 0 through 7}"
+
+    if [[ "${NNODES}" != "8" || "${NPROC_PER_NODE}" != "4" ]]; then
+        echo "The first supported recipe requires NNODES=8 and NPROC_PER_NODE=4; got ${NNODES} and ${NPROC_PER_NODE}." >&2
+        return 1
+    fi
+    if [[ ! "${NODE_RANK}" =~ ^[0-7]$ ]]; then
+        echo "NODE_RANK must be an integer from 0 through 7; got ${NODE_RANK}." >&2
+        return 1
+    fi
+}
+
+
+prepare_assets() {
+    local dataset_dir="$1"
+    local vae_path="$2"
+    local teacher_dcp="$3"
+    local student_dcp="$4"
+    local dataset_marker="${dataset_dir}/sft_dataset_bridge/train/video_dataset_file.jsonl"
+    local teacher_marker="${teacher_dcp}/model/.metadata"
+    local student_marker="${student_dcp}/model/.metadata"
+
+    if [[ "${NODE_RANK}" == "0" ]]; then
+        if [[ ! -f "${dataset_marker}" ]]; then
+            run_command "${UVX_BIN}" hf@latest download \
+                --repo-type dataset \
+                "nvidia/BridgeData2-Subset-Synthetic-Captions" \
+                --revision "${BRIDGE_DATA2_REVISION}" \
+                --local-dir "${dataset_dir}"
+        fi
+        if [[ ! -f "${vae_path}" ]]; then
+            run_command "${UVX_BIN}" hf@latest download \
+                "Wan-AI/Wan2.2-TI2V-5B" \
+                "Wan2.2_VAE.pth" \
+                --local-dir "$(dirname "${vae_path}")"
+        fi
+        if [[ ! -f "${teacher_marker}" ]]; then
+            run_command env \
+                "WORLD_SIZE=1" \
+                "RANK=0" \
+                "LOCAL_RANK=0" \
+                "LOCAL_WORLD_SIZE=1" \
+                "${PYTHON_BIN}" -m cosmos_framework.scripts.convert_model_to_dcp \
+                -o "${teacher_dcp}" \
+                --checkpoint-path "${TEACHER_CHECKPOINT_NAME}"
+        fi
+        if [[ ! -f "${student_marker}" ]]; then
+            run_command env \
+                "WORLD_SIZE=1" \
+                "RANK=0" \
+                "LOCAL_RANK=0" \
+                "LOCAL_WORLD_SIZE=1" \
+                "${PYTHON_BIN}" -m cosmos_framework.scripts.convert_model_to_dcp \
+                -o "${student_dcp}" \
+                --checkpoint-path "${STUDENT_CHECKPOINT_NAME}"
+        fi
+    fi
+
+    if [[ "${DRY_RUN}" != "1" ]]; then
+        wait_for_file "${dataset_marker}" "BridgeData2 dataset"
+        wait_for_file "${vae_path}" "Wan2.2 VAE"
+        wait_for_file "${teacher_marker}" "teacher DCP checkpoint"
+        wait_for_file "${student_marker}" "student DCP checkpoint"
+    fi
+}
+
+
+build_training_config() {
+    local config_path="$1"
+    local dataset_path="$2"
+    local teacher_dcp="$3"
+    local student_dcp="$4"
+
+    if [[ "${NODE_RANK}" == "0" ]]; then
+        run_command "${PYTHON_BIN}" "${DISTILL_SCRIPT_DIR}/build_distillation_config.py" \
+            --recipe-toml "${DISTILL_RECIPE_TOML}" \
+            --dataset-path "${dataset_path}" \
+            --teacher-checkpoint "${teacher_dcp}/model" \
+            --student-checkpoint "${student_dcp}/model" \
+            --output "${config_path}" \
+            --validate-only
+    fi
+    if [[ "${DRY_RUN}" != "1" ]]; then
+        wait_for_file "${config_path}" "generated ${DISTILL_MODE} config"
+    fi
+}
+
+
+run_training_phase() {
+    local config_path="$1"
+    local invocation_root="$2"
+    local max_iter="$3"
+    local resume_option="$4"
+
+    run_command env \
+        "IMAGINAIRE_OUTPUT_ROOT=${IMAGINAIRE_OUTPUT_ROOT}" \
+        "WAN_VAE_PATH=${WAN_VAE_PATH}" \
+        "COSMOS_TRAINING=1" \
+        "PYTORCH_ALLOC_CONF=expandable_segments:True" \
+        "LD_LIBRARY_PATH=" \
+        "${TORCHRUN_BIN}" \
+        "--nnodes=${NNODES}" \
+        "--nproc-per-node=${NPROC_PER_NODE}" \
+        "--node-rank=${NODE_RANK}" \
+        "--master-addr=${MASTER_ADDR}" \
+        "--master-port=${MASTER_PORT}" \
+        -m cosmos_framework.scripts._train \
+        -o "${invocation_root}" \
+        --config-file "${config_path}" \
+        "${resume_option}" \
+        --config-overrides "trainer.max_iter=${max_iter}"
+}
+
+
+export_student_checkpoint() {
+    local invocation_root="$1"
+    local job_name="cosmos3_super_${DISTILL_MODE}_dmd2_smoke"
+    local run_dir="${invocation_root}/${job_name}"
+    local checkpoint_path="${run_dir}/job/checkpoints/iter_000000006"
+
+    if [[ "${NODE_RANK}" == "0" && "${EXPORT_AFTER_TRAIN}" == "1" ]]; then
+        run_command env \
+            "WORLD_SIZE=1" \
+            "RANK=0" \
+            "LOCAL_RANK=0" \
+            "LOCAL_WORLD_SIZE=1" \
+            "${PYTHON_BIN}" -m cosmos_framework.scripts.export_model \
+            --checkpoint-path "${checkpoint_path}" \
+            --config-file "${run_dir}/config.yaml" \
+            --student-only-checkpoint-metadata \
+            -o "${run_dir}/student"
+    fi
+}
+
+
+run_distillation() {
+    NNODES="${NNODES:-8}"
+    NPROC_PER_NODE="${NPROC_PER_NODE:-4}"
+    DRY_RUN="${DRY_RUN:-0}"
+    EXPORT_AFTER_TRAIN="${EXPORT_AFTER_TRAIN:-1}"
+    PYTHON_BIN="${PYTHON_BIN:-python}"
+    TORCHRUN_BIN="${TORCHRUN_BIN:-torchrun}"
+    UVX_BIN="${UVX_BIN:-uvx}"
+
+    validate_launch_environment
+
+    local dataset_dir="${DISTILL_ROOT}/data/BridgeData2-Subset-Synthetic-Captions"
+    local dataset_path="${dataset_dir}/sft_dataset_bridge"
+    local vae_path="${DISTILL_ROOT}/checkpoints/wan22_vae/Wan2.2_VAE.pth"
+    # DMD2RFModel selects the regular ``net.*`` branch for converted checkpoints
+    # whose model directory ends in ``.dcp/model``.
+    local teacher_dcp="${DISTILL_ROOT}/checkpoints/${DISTILL_MODE}/teacher.dcp"
+    local student_dcp="${DISTILL_ROOT}/checkpoints/${DISTILL_MODE}/student.dcp"
+    local config_path="${DISTILL_ROOT}/configs/distillation_${DISTILL_MODE}.yaml"
+    local invocation_root="${DISTILL_ROOT}/outputs/invocations/${DISTILL_MODE}"
+
+    mkdir -p \
+        "${DISTILL_ROOT}/configs" \
+        "${DISTILL_ROOT}/outputs/invocations" \
+        "$(dirname "${vae_path}")" \
+        "$(dirname "${teacher_dcp}")"
+
+    WAN_VAE_PATH="${vae_path}"
+    IMAGINAIRE_OUTPUT_ROOT="${DISTILL_ROOT}/outputs/train"
+    COSMOS_TRAINING=1
+    LD_LIBRARY_PATH=""
+    export WAN_VAE_PATH IMAGINAIRE_OUTPUT_ROOT COSMOS_TRAINING LD_LIBRARY_PATH
+
+    echo "Mode: ${DISTILL_MODE}"
+    echo "Teacher model: ${TEACHER_MODEL_REPO}"
+    echo "Student model: ${STUDENT_MODEL_REPO}"
+    echo "Topology: ${NNODES} nodes x ${NPROC_PER_NODE} GPUs"
+
+    prepare_assets "${dataset_dir}" "${vae_path}" "${teacher_dcp}" "${student_dcp}"
+    build_training_config "${config_path}" "${dataset_path}" "${teacher_dcp}" "${student_dcp}"
+    run_training_phase "${config_path}" "${invocation_root}" 5 --no-resume
+    run_training_phase "${config_path}" "${invocation_root}" 6 --resume
+    export_student_checkpoint "${invocation_root}"
+}

--- a/cookbooks/cosmos3/generator/audiovisual/distill/launch_distillation_i2v.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/launch_distillation_i2v.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DISTILL_MODE="i2v"
+DISTILL_RECIPE_TOML="${SCRIPT_DIR}/toml/distillation_i2v.toml"
+TEACHER_MODEL_REPO="nvidia/Cosmos3-Super-Image2Video"
+STUDENT_MODEL_REPO="nvidia/Cosmos3-Super-Image2Video-4Step"
+TEACHER_CHECKPOINT_NAME="Cosmos3-Super-Image2Video"
+STUDENT_CHECKPOINT_NAME="Cosmos3-Super-Image2Video-4Step"
+
+source "${SCRIPT_DIR}/common.sh"
+run_distillation

--- a/cookbooks/cosmos3/generator/audiovisual/distill/launch_distillation_t2i.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/launch_distillation_t2i.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+DISTILL_MODE="t2i"
+DISTILL_RECIPE_TOML="${SCRIPT_DIR}/toml/distillation_t2i.toml"
+TEACHER_MODEL_REPO="nvidia/Cosmos3-Super-Text2Image"
+STUDENT_MODEL_REPO="nvidia/Cosmos3-Super-Text2Image-4Step"
+TEACHER_CHECKPOINT_NAME="Cosmos3-Super-Text2Image"
+STUDENT_CHECKPOINT_NAME="Cosmos3-Super-Text2Image-4Step"
+
+source "${SCRIPT_DIR}/common.sh"
+run_distillation

--- a/cookbooks/cosmos3/generator/audiovisual/distill/toml/distillation_i2v.toml
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/toml/distillation_i2v.toml
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# Short DMD2 Image2Video integration smoke. This is not a reproduction recipe.
+mode = "i2v"
+
+[job]
+project = "cosmos3"
+group = "distillation"
+name = "cosmos3_super_i2v_dmd2_smoke"
+wandb_mode = "disabled"
+
+[model]
+resolution = "480"
+max_num_tokens_after_packing = 45056
+lora_enabled = false
+ema_enabled = true
+compile_enabled = true
+base_fps = 16
+rectified_flow_shift = { "256" = 3, "480" = 5, "720" = 10 }
+rectified_flow_loss_scale = 10.0
+train_time_video_distribution = "uniform"
+simulation_mode = "backward"
+teacher_guidance = 6.0
+student_update_freq = 5
+vsd_loss_reduction = "mean"
+fake_score_loss_reduction = "active_mean"
+warmup_student_steps = 0
+warmup_critic_steps = 0
+grad_clip = true
+
+[model.parallelism]
+data_parallel_shard_degree = 32
+context_parallel_shard_degree = 1
+
+[model.fixed_step_sampler]
+sample_type = "sde"
+t_list = [1.0, 0.9375, 0.8333333333333334, 0.625]
+
+[optimizer.net]
+lr = 2.0e-6
+betas = [0.0, 0.999]
+
+[optimizer.fake_score]
+lr = 4.0e-7
+betas = [0.0, 0.999]
+
+[trainer]
+distributed_parallelism = "fsdp"
+grad_accum_iter = 1
+logging_iter = 1
+max_iter = 5
+seed = 42
+recompile_limit = 100
+
+[checkpoint]
+save_iter = 5
+strict_resume = true
+
+[dataloader_train]
+num_video_frames = 61
+conditioning_config = { "1" = 1.0 }
+append_duration_fps_timestamps = true
+conditioning_fps_noise_std = 0.1
+max_caption_tokens = 2048
+max_samples_per_batch = 1
+batch_size = 1
+num_workers = 4
+prefetch_factor = 4

--- a/cookbooks/cosmos3/generator/audiovisual/distill/toml/distillation_t2i.toml
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/toml/distillation_t2i.toml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# Short DMD2 Text2Image integration smoke. This is not a reproduction recipe.
+mode = "t2i"
+
+[job]
+project = "cosmos3"
+group = "distillation"
+name = "cosmos3_super_t2i_dmd2_smoke"
+wandb_mode = "disabled"
+
+[model]
+resolution = "768"
+max_num_tokens_after_packing = 45056
+lora_enabled = false
+ema_enabled = true
+compile_enabled = true
+base_fps = 24
+rectified_flow_shift = { "256" = 3, "480" = 5, "720" = 5, "768" = 5 }
+rectified_flow_loss_scale = 10.0
+train_time_video_distribution = "waver"
+simulation_mode = "backward"
+teacher_guidance = 6.0
+student_update_freq = 5
+vsd_loss_reduction = "mean"
+fake_score_loss_reduction = "active_mean"
+warmup_student_steps = 0
+warmup_critic_steps = 0
+grad_clip = true
+
+[model.parallelism]
+data_parallel_shard_degree = 32
+context_parallel_shard_degree = 1
+
+[model.fixed_step_sampler]
+sample_type = "sde"
+t_list = [1.0, 0.9375, 0.8333333333333334, 0.625]
+
+[optimizer.net]
+lr = 2.0e-6
+betas = [0.0, 0.999]
+
+[optimizer.fake_score]
+lr = 4.0e-7
+betas = [0.0, 0.999]
+
+[trainer]
+distributed_parallelism = "fsdp"
+grad_accum_iter = 1
+logging_iter = 1
+max_iter = 5
+seed = 42
+recompile_limit = 100
+
+[checkpoint]
+save_iter = 5
+strict_resume = true
+
+[dataloader_train]
+num_video_frames = 1
+append_duration_fps_timestamps = false
+conditioning_fps_noise_std = 0.0
+max_caption_tokens = 2048
+max_samples_per_batch = 1
+batch_size = 1
+num_workers = 4
+prefetch_factor = 4

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/README.md
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/README.md
@@ -6,8 +6,9 @@ Supervised fine-tuning (SFT) of the Cosmos3 video generator on your own captione
 | --- | --- | --- | --- |
 | Vision SFT (full) | `launch_sft_vision_nano.sh` | Cosmos3-Nano | [BridgeData2-Subset-Synthetic-Captions](https://huggingface.co/datasets/nvidia/BridgeData2-Subset-Synthetic-Captions) |
 | Vision SFT (LoRA) | `launch_sft_vision_super.sh` | Cosmos3-Super | same as above |
+| Vision SFT (full) | `launch_sft_vision_edge.sh` | Cosmos3-Edge | same as above |
 
-Both recipes train on structured-JSON captions (`caption_json`, the model's native prompt format), so training stays aligned with inference.
+All recipes train on structured-JSON captions (`caption_json`, the model's native prompt format), so training stays aligned with inference. The Cosmos3-Edge recipe is a full fine-tune of the compact 2B dense Nemotron backbone (no audio/sound tokenizer); at 2B it also fits a 4-GPU node.
 
 ## Prerequisites
 
@@ -25,6 +26,8 @@ Each launcher is a complete recipe — run it from this folder and it downloads 
 bash launch_sft_vision_nano.sh      # full SFT on Cosmos3-Nano
 # or
 bash launch_sft_vision_super.sh     # LoRA SFT on Cosmos3-Super
+# or
+bash launch_sft_vision_edge.sh      # full SFT on Cosmos3-Edge (2B; also fits a 4-GPU node)
 ```
 
 Paths are fixed at the top of each script (under this git-ignored folder) — edit them there to put data or checkpoints on another filesystem.
@@ -48,6 +51,17 @@ python -m cosmos_framework.scripts.export_model \
 ```
 
 Use the exported `$RUN_DIR/model` with the [audiovisual inference cookbook](../README.md).
+
+## Convert to Diffusers
+
+Convert the export into a Diffusers pipeline:
+
+```shell
+python -m cosmos_framework.scripts.convert_model_to_diffusers \
+    --checkpoint-path "$RUN_DIR/model" -o "$RUN_DIR/diffusers"
+```
+
+The input is the Hugging Face directory produced by `export_model` above (not a raw DCP checkpoint), so run the export first. See the [Export and Convert Checkpoints](../../../../../README.md#export-and-convert-checkpoints) overview for details.
 
 ## Advanced configuration
 

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_edge.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_edge.sh
@@ -2,9 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: OpenMDW-1.1
 
-# Complete recipe: Vision SFT on Cosmos3-Nano (T2V / I2V / V2V, 8x H100).
+# Complete recipe: Vision SFT on Cosmos3-Edge (T2V / I2V / V2V, 8x H100 or 4x GB200).
+# Full fine-tune of the compact 2B dense Nemotron backbone — same dataset and
+# dataflow as the Cosmos3-Nano recipe.
 # Run from this folder with the cosmos-framework venv active (see README):
-#   bash launch_sft_vision_nano.sh
+#   bash launch_sft_vision_edge.sh
 # It downloads the data, prepares the base checkpoint, and trains — in order.
 # Paths are fixed under this folder; edit them below to relocate.
 
@@ -12,7 +14,7 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 DATASET_DIR="$PWD/data/BridgeData2-Subset-Synthetic-Captions"
-CHECKPOINT_DIR="$PWD/checkpoints/Cosmos3-Nano"
+CHECKPOINT_DIR="$PWD/checkpoints/Cosmos3-Edge"
 VAE_PATH="$PWD/checkpoints/wan22_vae/Wan2.2_VAE.pth"
 
 # 1. Download the SFT dataset (skipped if present; license-gated — accept terms + 'uvx hf@latest auth login').
@@ -26,9 +28,10 @@ if [[ ! -f "$VAE_PATH" ]]; then
     uvx hf@latest download Wan-AI/Wan2.2-TI2V-5B Wan2.2_VAE.pth --local-dir "$(dirname "$VAE_PATH")"
 fi
 
-# 3. Convert the base checkpoint to DCP (skipped if present).
+# 3. Convert the base checkpoint to DCP (skipped if present). Cosmos3-Edge is a
+#    registered checkpoint name — the converter fetches it from HF, same as Nano.
 if [[ ! -d "$CHECKPOINT_DIR" ]]; then
-    python -m cosmos_framework.scripts.convert_model_to_dcp -o "$CHECKPOINT_DIR" --checkpoint-path Cosmos3-Nano
+    python -m cosmos_framework.scripts.convert_model_to_dcp -o "$CHECKPOINT_DIR" --checkpoint-path Cosmos3-Edge
 fi
 
 # 4. Train (8-GPU FSDP). The TOML reads these three paths from the environment.
@@ -37,9 +40,9 @@ export BASE_CHECKPOINT_PATH="$CHECKPOINT_DIR"
 export WAN_VAE_PATH="$VAE_PATH"
 # The model configs reference their packaged JSONs relative to the framework
 # root, so run torchrun from there (recipe paths stay pinned to this folder).
-TOML_PATH="$PWD/toml/sft_config/vision_sft_nano.toml"
+TOML_PATH="$PWD/toml/sft_config/vision_sft_edge.toml"
 OUTPUT_ROOT="$PWD/outputs/train"
 cd "$(python -c 'import pathlib, cosmos_framework; print(pathlib.Path(cosmos_framework.__file__).resolve().parents[1])')"
-# On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
+# Edge is only 2B — on a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
 IMAGINAIRE_OUTPUT_ROOT="$OUTPUT_ROOT" torchrun --nproc_per_node=8 \
     -m cosmos_framework.scripts.train --sft-toml="$TOML_PATH"

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/launch_sft_vision_super.sh
@@ -38,6 +38,11 @@ export PYTORCH_ALLOC_CONF="expandable_segments:True"
 export DATASET_PATH="$DATASET_DIR/sft_dataset_bridge"
 export BASE_CHECKPOINT_PATH="$CHECKPOINT_DIR"
 export WAN_VAE_PATH="$VAE_PATH"
+# The model configs reference their packaged JSONs relative to the framework
+# root, so run torchrun from there (recipe paths stay pinned to this folder).
+TOML_PATH="$PWD/toml/sft_config/vision_sft_super.toml"
+OUTPUT_ROOT="$PWD/outputs/train"
+cd "$(python -c 'import pathlib, cosmos_framework; print(pathlib.Path(cosmos_framework.__file__).resolve().parents[1])')"
 # On a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
-IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
-    -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/vision_sft_super.toml"
+IMAGINAIRE_OUTPUT_ROOT="$OUTPUT_ROOT" torchrun --nproc_per_node=8 \
+    -m cosmos_framework.scripts.train --sft-toml="$TOML_PATH"

--- a/cookbooks/cosmos3/generator/audiovisual/finetune/toml/sft_config/vision_sft_edge.toml
+++ b/cookbooks/cosmos3/generator/audiovisual/finetune/toml/sft_config/vision_sft_edge.toml
@@ -1,16 +1,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: OpenMDW-1.1
 
-# vision_sft_nano — T2V / I2V / V2V vision-only SFT (Qwen3-VL-8B / nano)
+# vision_sft_edge — full T2V/I2V/V2V SFT on Nemotron-2B-Dense-VL (Cosmos3-Edge tier).
 # Consumed by cosmos_framework.configs.toml_config.sft_config.load_experiment_from_toml.
-# Uses PackingDataLoader (no dataloader_train.seed slot — keep it omitted here).
+# Uses PackingDataLoader (no dataloader_train.seed slot — keep it omitted).
+#
+# Edge-tier counterpart of vision_sft_nano: same dataset + dataflow and the same
+# full-SFT knobs (EMA on, moe_gen optimizer allowlist, lr=1e-4), but on the compact
+# 2B dense Nemotron backbone (Cosmos3-Edge, no audio/sound tokenizer). Only 2B, so
+# it fits a 4-GPU (e.g. GB200x4) or 8-GPU allocation.
+#
+# Example launch (from cookbooks/cosmos3/generator/audiovisual/finetune/):
+#   bash launch_sft_vision_edge.sh
 
 [job]
 task         = "vfm"
-experiment   = "vision_sft_nano"
+experiment   = "vision_sft_edge"
 project      = "cosmos3"
 group        = "sft"
-name         = "vision_sft_nano"
+name         = "vision_sft_edge"
 wandb_mode   = "disabled"
 
 [model]
@@ -19,7 +27,7 @@ joint_attn_implementation    = "two_way"
 precision                    = "bfloat16"                # was [model.parallelism].precision
 
 [model.ema]
-enabled         = true
+enabled         = true                                   # edge: full SFT, EMA on (nano parity)
 rate            = 0.1
 iteration_shift = 0
 
@@ -49,6 +57,7 @@ keys_to_select = [
     "time_embedder",
     "vae2llm",
     "llm2vae",
+    "k_norm_und_for_gen",  # und-K norm trains with the gen pathway
 ]
 lr            = 1.0e-4                                 # tuned via LR sweep: full fine-tune converges faster at 1e-4 than 2e-5 (LoRA super stays 5e-4)
 weight_decay  = 0                                        # int matches legacy YAML repr

--- a/cookbooks/cosmos3/generator/audiovisual/run_with_cosmos_framework.ipynb
+++ b/cookbooks/cosmos3/generator/audiovisual/run_with_cosmos_framework.ipynb
@@ -20,7 +20,7 @@
     "python -m cosmos_framework.scripts.inference\n",
     "```\n",
     "\n",
-    "Run all Cosmos3-Nano examples first, then run the Cosmos3-Super T2V/I2V examples without audio. Each section uses the matching checkpoint explicitly.\n"
+    "Run the use cases top-to-bottom: Cosmos3-Nano, full Cosmos3-Super, the published four-step distilled T2I/I2V students, and Cosmos3-Edge. Each section uses the matching checkpoint explicitly. Cosmos3-Edge has no audio modules, so its examples run without audio.\n"
    ]
   },
   {
@@ -326,6 +326,22 @@
     "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
     "        \"enable_sound\": False,\n",
     "    },\n",
+    "    \"t2i_distilled\": {\n",
+    "        \"model\": \"Cosmos3-Super-Text2Image-4Step\",\n",
+    "        \"mode\": \"text2image\",\n",
+    "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
+    "        \"enable_sound\": False,\n",
+    "        \"sampling\": {\n",
+    "            \"num_steps\": 50,\n",
+    "            \"guidance\": 1.0,\n",
+    "            \"shift\": 3.0,\n",
+    "            \"fps\": 30,\n",
+    "            \"num_frames\": 1,\n",
+    "            \"resolution\": \"768\",\n",
+    "            \"aspect_ratio\": \"1,1\",\n",
+    "            \"seed\": 1,\n",
+    "        },\n",
+    "    },\n",
     "    \"t2v_nano_noaudio\": {\n",
     "        \"model\": \"Cosmos3-Nano\",\n",
     "        \"mode\": \"text2video\",\n",
@@ -360,6 +376,42 @@
     "    },\n",
     "    \"i2v_super_noaudio\": {\n",
     "        \"model\": \"Cosmos3-Super\",\n",
+    "        \"mode\": \"image2video\",\n",
+    "        \"prompt\": \"assets/prompts/image2video/car_driving.json\",\n",
+    "        \"image\": \"assets/images/image2video/car_driving.jpg\",\n",
+    "        \"enable_sound\": False,\n",
+    "    },\n",
+    "    \"i2v_distilled\": {\n",
+    "        \"model\": \"Cosmos3-Super-Image2Video-4Step\",\n",
+    "        \"mode\": \"image2video\",\n",
+    "        \"prompt\": \"assets/prompts/image2video/car_driving.json\",\n",
+    "        \"image\": \"assets/images/image2video/car_driving.jpg\",\n",
+    "        \"enable_sound\": False,\n",
+    "        \"sampling\": {\n",
+    "            \"num_steps\": 35,\n",
+    "            \"guidance\": 1.0,\n",
+    "            \"shift\": 10.0,\n",
+    "            \"fps\": 30,\n",
+    "            \"num_frames\": 121,\n",
+    "            \"resolution\": \"480\",\n",
+    "            \"aspect_ratio\": \"4,3\",\n",
+    "            \"seed\": 1,\n",
+    "        },\n",
+    "    },\n",
+    "    \"t2i_edge\": {\n",
+    "        \"model\": \"Cosmos3-Edge\",\n",
+    "        \"mode\": \"text2image\",\n",
+    "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
+    "        \"enable_sound\": False,\n",
+    "    },\n",
+    "    \"t2v_edge_noaudio\": {\n",
+    "        \"model\": \"Cosmos3-Edge\",\n",
+    "        \"mode\": \"text2video\",\n",
+    "        \"prompt\": \"assets/prompts/text2video/robot_kitchen.json\",\n",
+    "        \"enable_sound\": False,\n",
+    "    },\n",
+    "    \"i2v_edge_noaudio\": {\n",
+    "        \"model\": \"Cosmos3-Edge\",\n",
     "        \"mode\": \"image2video\",\n",
     "        \"prompt\": \"assets/prompts/image2video/car_driving.json\",\n",
     "        \"image\": \"assets/images/image2video/car_driving.jpg\",\n",
@@ -414,6 +466,7 @@
     "        \"negative_prompt\": negative_prompt,\n",
     "        \"enable_sound\": spec[\"enable_sound\"],\n",
     "        **FIXED_SAMPLING,\n",
+    "        **spec.get(\"sampling\", {}),\n",
     "    }\n",
     "    if spec[\"mode\"] == \"text2image\":\n",
     "        payload[\"num_frames\"] = 1\n",
@@ -484,7 +537,7 @@
    "source": [
     "## Use Cases\n",
     "\n",
-    "Run each use case top-to-bottom: create the JSON payload, run inference, then view the generated media. Nano examples come first; Super examples are last.\n"
+    "Run each use case top-to-bottom: create the JSON payload, run inference, then view the generated media. The published four-step students use four-GPU sharding for memory and are smoke examples, not production-quality reproduction claims.\n"
    ],
    "id": "79414d1d"
   },
@@ -618,6 +671,77 @@
    "metadata": {},
    "source": [
     "view_run(t2i_super_output)"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2i-distilled-section",
+   "metadata": {},
+   "source": [
+    "## Super 4-Step: Text to Image\n",
+    "\n",
+    "Run the published `nvidia/Cosmos3-Super-Text2Image-4Step` student on four GPUs. The model uses its fixed-step SDE schedule; `dp_shard_size=4` is the validated memory layout for the 32B checkpoint. Guardrails are disabled only for this controlled smoke example.\n",
+    "\n",
+    "### Create Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "t2i_distilled_payload, t2i_distilled_output, t2i_distilled_model = create_payload(\"t2i_distilled\", backend=\"pytorch\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "COSMOS_TRAINING=1 COSMOS_INTERNAL=0 CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" LD_LIBRARY_PATH= \\\n",
+    "\"$COSMOS3_UV_ENV/bin/torchrun\" \\\n",
+    "  --nproc-per-node=\"$COSMOS3_NUM_GPUS\" \\\n",
+    "  --master-addr=\"$COSMOS3_MASTER_ADDR\" \\\n",
+    "  --master-port=\"$COSMOS3_TEXT_MASTER_PORT\" \\\n",
+    "  -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=throughput \\\n",
+    "  -i \"$COSMOS3_PYTORCH_T2I_DISTILLED_INPUT\" \\\n",
+    "  -o \"$COSMOS3_PYTORCH_T2I_DISTILLED_OUTPUT\" \\\n",
+    "  --checkpoint-path \"Cosmos3-Super-Text2Image-4Step\" \\\n",
+    "  --dp-shard-size=4 --dp-replicate-size=1 \\\n",
+    "  --cp-size=1 --cfgp-size=1 \\\n",
+    "  --resolution=768 --aspect-ratio=1,1 \\\n",
+    "  --fps=30 --num-frames=1 \\\n",
+    "  --guidance=1.0 --seed=1 --no-guardrails"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### View Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "view_run(t2i_distilled_output)"
    ],
    "execution_count": null,
    "outputs": []
@@ -1022,6 +1146,293 @@
    ],
    "execution_count": null,
    "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i2v-distilled-section",
+   "metadata": {},
+   "source": [
+    "## Super 4-Step: Image to Video\n",
+    "\n",
+    "Run the published `nvidia/Cosmos3-Super-Image2Video-4Step` student on four GPUs using the existing public car-driving image and prompt. The model uses its fixed-step SDE schedule; `dp_shard_size=4` is the validated memory layout for the 32B checkpoint. Guardrails are disabled only for this controlled smoke example.\n",
+    "\n",
+    "### Create Payload\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "i2v_distilled_payload, i2v_distilled_output, i2v_distilled_model = create_payload(\"i2v_distilled\", backend=\"pytorch\")\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "COSMOS_TRAINING=1 COSMOS_INTERNAL=0 CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" LD_LIBRARY_PATH= \\\n",
+    "\"$COSMOS3_UV_ENV/bin/torchrun\" \\\n",
+    "  --nproc-per-node=\"$COSMOS3_NUM_GPUS\" \\\n",
+    "  --master-addr=\"$COSMOS3_MASTER_ADDR\" \\\n",
+    "  --master-port=\"$COSMOS3_IMAGE_MASTER_PORT\" \\\n",
+    "  -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=throughput \\\n",
+    "  -i \"$COSMOS3_PYTORCH_I2V_DISTILLED_INPUT\" \\\n",
+    "  -o \"$COSMOS3_PYTORCH_I2V_DISTILLED_OUTPUT\" \\\n",
+    "  --checkpoint-path \"Cosmos3-Super-Image2Video-4Step\" \\\n",
+    "  --dp-shard-size=4 --dp-replicate-size=1 \\\n",
+    "  --cp-size=1 --cfgp-size=1 \\\n",
+    "  --resolution=480 --aspect-ratio=4,3 \\\n",
+    "  --fps=30 --num-frames=121 \\\n",
+    "  --guidance=1.0 --seed=1 --no-guardrails\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### View Results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "view_run(i2v_distilled_output)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2i_edge-section",
+   "metadata": {},
+   "source": [
+    "## Edge: Text to Image\n",
+    "\n",
+    "Edge text-to-image generation using the same structured JSON prompt as the Nano/Super text-to-image sections. Edge has no audio modules, so it runs without audio.\n",
+    "\n",
+    "### Create Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "t2i_edge-create",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "t2i_edge_payload, t2i_edge_output, t2i_edge_model = create_payload(\"t2i_edge\", backend=\"pytorch\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2i_edge-run-md",
+   "metadata": {},
+   "source": [
+    "### Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "t2i_edge-run",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" LD_LIBRARY_PATH= \\\n",
+    "\"$COSMOS3_UV_ENV/bin/torchrun\" \\\n",
+    "  --nproc-per-node=\"$COSMOS3_NUM_GPUS\" \\\n",
+    "  --master-addr=\"$COSMOS3_MASTER_ADDR\" \\\n",
+    "  --master-port=\"$COSMOS3_TEXT_MASTER_PORT\" \\\n",
+    "  -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=throughput \\\n",
+    "  -i \"$COSMOS3_PYTORCH_T2I_EDGE_INPUT\" \\\n",
+    "  -o \"$COSMOS3_PYTORCH_T2I_EDGE_OUTPUT\" \\\n",
+    "  --checkpoint-path \"Cosmos3-Edge\" \\\n",
+    "  --seed=0\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2i_edge-view-md",
+   "metadata": {},
+   "source": [
+    "### View Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "t2i_edge-view",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "view_run(t2i_edge_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2v_edge_noaudio-section",
+   "metadata": {},
+   "source": [
+    "## Edge: Text to Video Without Audio\n",
+    "\n",
+    "Edge text-to-video generation with audio disabled (Edge has no audio modules).\n",
+    "\n",
+    "### Create Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "t2v_edge_noaudio-create",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "t2v_edge_noaudio_payload, t2v_edge_noaudio_output, t2v_edge_noaudio_model = create_payload(\"t2v_edge_noaudio\", backend=\"pytorch\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2v_edge_noaudio-run-md",
+   "metadata": {},
+   "source": [
+    "### Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "t2v_edge_noaudio-run",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" LD_LIBRARY_PATH= \\\n",
+    "\"$COSMOS3_UV_ENV/bin/torchrun\" \\\n",
+    "  --nproc-per-node=\"$COSMOS3_NUM_GPUS\" \\\n",
+    "  --master-addr=\"$COSMOS3_MASTER_ADDR\" \\\n",
+    "  --master-port=\"$COSMOS3_TEXT_MASTER_PORT\" \\\n",
+    "  -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=throughput \\\n",
+    "  -i \"$COSMOS3_PYTORCH_T2V_EDGE_NOAUDIO_INPUT\" \\\n",
+    "  -o \"$COSMOS3_PYTORCH_T2V_EDGE_NOAUDIO_OUTPUT\" \\\n",
+    "  --checkpoint-path \"Cosmos3-Edge\" \\\n",
+    "  --seed=0\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "t2v_edge_noaudio-view-md",
+   "metadata": {},
+   "source": [
+    "### View Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "t2v_edge_noaudio-view",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "view_run(t2v_edge_noaudio_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i2v_edge_noaudio-section",
+   "metadata": {},
+   "source": [
+    "## Edge: Image to Video Without Audio\n",
+    "\n",
+    "Edge image-to-video generation using its paired image asset, with audio disabled (Edge has no audio modules).\n",
+    "\n",
+    "### Create Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "i2v_edge_noaudio-create",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "i2v_edge_noaudio_payload, i2v_edge_noaudio_output, i2v_edge_noaudio_model = create_payload(\"i2v_edge_noaudio\", backend=\"pytorch\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i2v_edge_noaudio-run-md",
+   "metadata": {},
+   "source": [
+    "### Run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "i2v_edge_noaudio-run",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" LD_LIBRARY_PATH= \\\n",
+    "\"$COSMOS3_UV_ENV/bin/torchrun\" \\\n",
+    "  --nproc-per-node=\"$COSMOS3_NUM_GPUS\" \\\n",
+    "  --master-addr=\"$COSMOS3_MASTER_ADDR\" \\\n",
+    "  --master-port=\"$COSMOS3_IMAGE_MASTER_PORT\" \\\n",
+    "  -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=throughput \\\n",
+    "  -i \"$COSMOS3_PYTORCH_I2V_EDGE_NOAUDIO_INPUT\" \\\n",
+    "  -o \"$COSMOS3_PYTORCH_I2V_EDGE_NOAUDIO_OUTPUT\" \\\n",
+    "  --checkpoint-path \"Cosmos3-Edge\" \\\n",
+    "  --seed=0\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i2v_edge_noaudio-view-md",
+   "metadata": {},
+   "source": [
+    "### View Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "i2v_edge_noaudio-view",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "view_run(i2v_edge_noaudio_output)"
+   ]
   }
  ],
  "metadata": {

--- a/cookbooks/cosmos3/generator/audiovisual/run_with_vllm_omni.ipynb
+++ b/cookbooks/cosmos3/generator/audiovisual/run_with_vllm_omni.ipynb
@@ -5,11 +5,13 @@
    "id": "license-header",
    "metadata": {},
    "source": [
-    "<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\nSPDX-License-Identifier: OpenMDW-1.1 -->"
+    "<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
+    "SPDX-License-Identifier: OpenMDW-1.1 -->"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d88fe9a8",
    "metadata": {},
    "source": [
     "# Cosmos3 Generator Audiovisual with vLLM Omni\n",
@@ -17,11 +19,11 @@
     "This notebook calls already-running vLLM Omni Cosmos3 servers with direct `curl` requests from Python.\n",
     "\n",
     "The examples are split into Cosmos3-Nano and Cosmos3-Super sections. Each section is self-contained, so you can run just one. Each section targets the matching model endpoint.\n"
-   ],
-   "id": "d88fe9a8"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "49df4e61",
    "metadata": {},
    "source": [
     "## 1. Prerequisites\n",
@@ -35,11 +37,11 @@
     "export COSMOS3_VLLM_NANO_BASE_URL=http://localhost:8000\n",
     "export COSMOS3_VLLM_SUPER_BASE_URL=http://localhost:8000\n",
     "```\n"
-   ],
-   "id": "49df4e61"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "26776c50",
    "metadata": {},
    "source": [
     "## 2. Start the Server\n",
@@ -86,6 +88,48 @@
     "  --init-timeout 1800\n",
     "```\n",
     "\n",
+    "### Docker Image: Cosmos3-Super-Text2Image-4Step, Cosmos3-Super-Image2Video-4Step\n",
+    "\n",
+    "`Cosmos3-Super-Text2Image-4Step` and `Cosmos3-Super-Image2Video-4Step` are distilled models which require fewer inference steps for Text2Image and Image2Video tasks respectively. \n",
+    "\n",
+    "#### Cosmos3-Super-Text2Image-4Step\n",
+    "\n",
+    "```bash\n",
+    "docker run --runtime nvidia --gpus all \\\n",
+    "  -v ~/.cache/huggingface:/root/.cache/huggingface \\\n",
+    "  -v \"$(pwd):/workspace\" \\\n",
+    "  -p 8000:8000 \\\n",
+    "  --ipc=host \\\n",
+    "  vllm/vllm-omni:cosmos3 \\\n",
+    "  vllm serve nvidia/Cosmos3-Super-Text2Image-4Step \\\n",
+    "  --omni \\\n",
+    "  --model-class-name Cosmos3OmniDiffusersPipeline \\\n",
+    "  --allowed-local-media-path / \\\n",
+    "  --tensor-parallel-size 4 \\\n",
+    "  --enable-layerwise-offload \\\n",
+    "  --port 8000 \\\n",
+    "  --init-timeout 1800\n",
+    "```\n",
+    "\n",
+    "#### Cosmos3-Super-Image2Video-4Step\n",
+    "\n",
+    "```bash\n",
+    "docker run --runtime nvidia --gpus all \\\n",
+    "  -v ~/.cache/huggingface:/root/.cache/huggingface \\\n",
+    "  -v \"$(pwd):/workspace\" \\\n",
+    "  -p 8000:8000 \\\n",
+    "  --ipc=host \\\n",
+    "  vllm/vllm-omni:cosmos3 \\\n",
+    "  vllm serve nvidia/Cosmos3-Super-Image2Video-4Step \\\n",
+    "  --omni \\\n",
+    "  --model-class-name Cosmos3OmniDiffusersPipeline \\\n",
+    "  --allowed-local-media-path / \\\n",
+    "  --tensor-parallel-size 4 \\\n",
+    "  --enable-layerwise-offload \\\n",
+    "  --port 8000 \\\n",
+    "  --init-timeout 1800\n",
+    "```\n",
+    "\n",
     "### CFG Parallel\n",
     "\n",
     "Use `--cfg-parallel-size 2` to run the positive and negative CFG branches in parallel on two GPUs:\n",
@@ -100,24 +144,25 @@
     "  --init-timeout 1800\n",
     "```\n",
     "\n",
-    "For Cosmos3, set CFG strength with the request-level `guidance_scale` field. Do not use `true_cfg_scale` for CFG Parallel with these Cosmos3 examples.\n",
-    ""
-   ],
-   "id": "26776c50"
+    "For Cosmos3, set CFG strength with the request-level `guidance_scale` field. Do not use `true_cfg_scale` for CFG Parallel with these Cosmos3 examples.\n"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4412f2f9",
    "metadata": {},
    "source": [
     "## 3. Configure Paths and Endpoints\n",
     "\n",
     "This setup cell only configures repo/output paths and vLLM endpoint settings.\n"
-   ],
-   "id": "4412f2f9"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "23f04a90",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "import os\n",
@@ -139,6 +184,8 @@
     "VLLM_ENDPOINTS = {\n",
     "    \"Cosmos3-Nano\": os.environ.get(\"COSMOS3_VLLM_NANO_BASE_URL\", DEFAULT_VLLM_BASE_URL),\n",
     "    \"Cosmos3-Super\": os.environ.get(\"COSMOS3_VLLM_SUPER_BASE_URL\", DEFAULT_VLLM_BASE_URL),\n",
+    "    \"Cosmos3-Super-Text2Image-4Step\": os.environ.get(\"COSMOS3_VLLM_SUPER_BASE_URL\", DEFAULT_VLLM_BASE_URL),\n",
+    "    \"Cosmos3-Super-Image2Video-4Step\": os.environ.get(\"COSMOS3_VLLM_SUPER_BASE_URL\", DEFAULT_VLLM_BASE_URL),\n",
     "}\n",
     "\n",
     "os.environ[\"COSMOS3_AUDIOVISUAL_OUTPUT_ROOT\"] = str(COSMOS3_AUDIOVISUAL_OUTPUT_ROOT)\n",
@@ -148,22 +195,22 @@
     "print(\"COSMOS3_AUDIOVISUAL_OUTPUT_ROOT:\", COSMOS3_AUDIOVISUAL_OUTPUT_ROOT)\n",
     "for model, endpoint in VLLM_ENDPOINTS.items():\n",
     "    print(f\"{model} endpoint: {endpoint}\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "23f04a90"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "73369e7f",
    "metadata": {},
    "source": [
     "## 4. Verify Endpoint Configuration\n"
-   ],
-   "id": "73369e7f"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "1c50e183",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from urllib.parse import urlparse\n",
     "\n",
@@ -178,22 +225,22 @@
     "    print(\"  videos sync:\", f\"{api_root}/videos/sync\")\n",
     "    print(\"  scheme:\", parsed.scheme)\n",
     "    print(\"  host:\", parsed.netloc)\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "1c50e183"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c1d161a6",
    "metadata": {},
    "source": [
     "## 5. Preview Available Inputs\n"
-   ],
-   "id": "c1d161a6"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "973ea472",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "import json\n",
@@ -222,22 +269,22 @@
     "        if image_path.suffix.lower() in {\".jpg\", \".jpeg\", \".png\", \".webp\", \".bmp\"}:\n",
     "            print(f\"  {image_path.name}\")\n",
     "            display(Image(filename=str(image_path), width=420))\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "973ea472"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "cfa34351",
    "metadata": {},
    "source": [
     "## 6. Define Asset Sets, Payload Helpers, Request Helpers, and Viewer Helpers\n"
-   ],
-   "id": "cfa34351"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "af5dd1c8",
    "metadata": {},
+   "outputs": [],
    "source": [
     "import json\n",
     "import os\n",
@@ -311,8 +358,20 @@
     "        \"image\": \"assets/images/image2video/car_driving.jpg\",\n",
     "        \"enable_sound\": False,\n",
     "    },\n",
+    "    \"t2i_distil\": {\n",
+    "        \"model\": \"Cosmos3-Super-Text2Image-4Step\",\n",
+    "        \"mode\": \"text2image\",\n",
+    "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
+    "        \"enable_sound\": False,\n",
+    "    },\n",
+    "    \"i2v_distil\": {\n",
+    "        \"model\": \"Cosmos3-Super-Image2Video-4Step\",\n",
+    "        \"mode\": \"image2video\",\n",
+    "        \"prompt\": \"assets/prompts/image2video/car_driving.json\",\n",
+    "        \"image\": \"assets/images/image2video/car_driving.jpg\",\n",
+    "        \"enable_sound\": False,\n",
+    "    },\n",
     "}\n",
-    "\n",
     "\n",
     "def asset_path(relative_path: str) -> Path:\n",
     "    path = COSMOS3_AUDIOVISUAL_ROOT / relative_path\n",
@@ -576,31 +635,29 @@
     "    for src in images:\n",
     "        print(f\"source: {src} ({src.stat().st_size // 1024} KB)\")\n",
     "        display(Image(filename=str(src), width=720))\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "af5dd1c8"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "9ffaab0e",
    "metadata": {},
    "source": [
     "Run each use case top-to-bottom: create the JSON payload, run inference, then view the generated media. The examples are grouped by model size below. The Cosmos3-Nano and Cosmos3-Super sections are independent, so you can run just one.\n"
-   ],
-   "id": "9ffaab0e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e7d284db",
    "metadata": {},
    "source": [
     "# Cosmos3-Nano Examples\n",
     "\n",
     "Use cases for the `Cosmos3-Nano` model. This section is self-contained; you can run it without the Cosmos3-Super section below.\n"
-   ],
-   "id": "e7d284db"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "27bf6dce",
    "metadata": {},
    "source": [
     "## Nano: Text to Image\n",
@@ -608,57 +665,57 @@
     "Nano text-to-image generation using a structured JSON prompt.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "27bf6dce"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "383f6351",
    "metadata": {},
+   "outputs": [],
    "source": [
     "t2i_payload, t2i_output, t2i_model = create_payload(\"t2i\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "383f6351"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "d3c59500",
    "metadata": {},
    "source": [
     "### Run\n"
-   ],
-   "id": "d3c59500"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "97b4b312",
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(t2i_payload, t2i_output, model=\"Cosmos3-Nano\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "97b4b312"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "c027b956",
    "metadata": {},
    "source": [
     "### View Results\n"
-   ],
-   "id": "c027b956"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "8fe6e3ed",
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(t2i_output)\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "8fe6e3ed"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "0e7d3092",
    "metadata": {},
    "source": [
     "## Nano: Text to Video Without Audio\n",
@@ -666,57 +723,57 @@
     "Nano text-to-video generation with audio disabled.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "0e7d3092"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "b2e85424",
    "metadata": {},
+   "outputs": [],
    "source": [
     "t2v_nano_noaudio_payload, t2v_nano_noaudio_output, t2v_nano_noaudio_model = create_payload(\"t2v_nano_noaudio\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "b2e85424"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "e4fa0cdd",
    "metadata": {},
    "source": [
     "### Run\n"
-   ],
-   "id": "e4fa0cdd"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "9db2a1a5",
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(t2v_nano_noaudio_payload, t2v_nano_noaudio_output, model=\"Cosmos3-Nano\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "9db2a1a5"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1bc8a331",
    "metadata": {},
    "source": [
     "### View Results\n"
-   ],
-   "id": "1bc8a331"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "87917755",
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(t2v_nano_noaudio_output)\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "87917755"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "816e9b09",
    "metadata": {},
    "source": [
     "## Nano: Text to Video with Audio\n",
@@ -724,57 +781,57 @@
     "Nano text-to-video generation with generated audio.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "816e9b09"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "e8450feb",
    "metadata": {},
+   "outputs": [],
    "source": [
     "t2vs_payload, t2vs_output, t2vs_model = create_payload(\"t2vs\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "e8450feb"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "b6bd6ec8",
    "metadata": {},
    "source": [
     "### Run\n"
-   ],
-   "id": "b6bd6ec8"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "685d18d6",
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(t2vs_payload, t2vs_output, model=\"Cosmos3-Nano\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "685d18d6"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "93743159",
    "metadata": {},
    "source": [
     "### View Results\n"
-   ],
-   "id": "93743159"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "a4bc049a",
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(t2vs_output)\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "a4bc049a"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1cf05248",
    "metadata": {},
    "source": [
     "## Nano: Image to Video Without Audio\n",
@@ -782,57 +839,57 @@
     "Nano image-to-video generation using its paired image asset, with audio disabled.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "1cf05248"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "91e28e16",
    "metadata": {},
+   "outputs": [],
    "source": [
     "i2v_nano_noaudio_payload, i2v_nano_noaudio_output, i2v_nano_noaudio_model = create_payload(\"i2v_nano_noaudio\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "91e28e16"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "ef42f84d",
    "metadata": {},
    "source": [
     "### Run\n"
-   ],
-   "id": "ef42f84d"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "4ec848e8",
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(i2v_nano_noaudio_payload, i2v_nano_noaudio_output, model=\"Cosmos3-Nano\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "4ec848e8"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "dea78891",
    "metadata": {},
    "source": [
     "### View Results\n"
-   ],
-   "id": "dea78891"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "ae7a16ed",
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(i2v_nano_noaudio_output)\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "ae7a16ed"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1860e911",
    "metadata": {},
    "source": [
     "## Nano: Image to Video with Audio\n",
@@ -840,67 +897,67 @@
     "Nano image-to-video generation using its paired image asset and generated audio.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "1860e911"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "37c40d8e",
    "metadata": {},
+   "outputs": [],
    "source": [
     "i2vs_payload, i2vs_output, i2vs_model = create_payload(\"i2vs\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "37c40d8e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "637e5e87",
    "metadata": {},
    "source": [
     "### Run\n"
-   ],
-   "id": "637e5e87"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "b4a4c308",
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(i2vs_payload, i2vs_output, model=\"Cosmos3-Nano\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "b4a4c308"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "62994915",
    "metadata": {},
    "source": [
     "### View Results\n"
-   ],
-   "id": "62994915"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "58a28e11",
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(i2vs_output)\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "58a28e11"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "fe62931e",
    "metadata": {},
    "source": [
     "# Cosmos3-Super Examples\n",
     "\n",
     "The same use cases for the larger `Cosmos3-Super` model. This section is self-contained; you can run it without the Cosmos3-Nano section above.\n"
-   ],
-   "id": "fe62931e"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "466c6bac",
    "metadata": {},
    "source": [
     "## Super: Text to Image\n",
@@ -908,57 +965,57 @@
     "Super text-to-image generation using the same structured JSON prompt.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "466c6bac"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "575653c1",
    "metadata": {},
+   "outputs": [],
    "source": [
     "t2i_super_payload, t2i_super_output, t2i_super_model = create_payload(\"t2i_super\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "575653c1"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "42776c8b",
    "metadata": {},
    "source": [
     "### Run\n"
-   ],
-   "id": "42776c8b"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "824783c8",
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(t2i_super_payload, t2i_super_output, model=\"Cosmos3-Super\")\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "824783c8"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "1ebf0b15",
    "metadata": {},
    "source": [
     "### View Results\n"
-   ],
-   "id": "1ebf0b15"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "b0fba2bb",
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(t2i_super_output)\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "b0fba2bb"
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "f608eaa7",
    "metadata": {},
    "source": [
     "## Super: Text to Video Without Audio\n",
@@ -966,17 +1023,16 @@
     "Super text-to-video generation with audio disabled.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "f608eaa7"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "t2v_super_noaudio_payload, t2v_super_noaudio_output, t2v_super_noaudio_model = create_payload(\"t2v_super_noaudio\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -987,12 +1043,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(t2v_super_noaudio_payload, t2v_super_noaudio_output, model=\"Cosmos3-Super\")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1003,15 +1059,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(t2v_super_noaudio_output)\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "367f4161",
    "metadata": {},
    "source": [
     "## Super: Image to Video Without Audio\n",
@@ -1019,17 +1076,16 @@
     "Super image-to-video generation using its paired image asset, with audio disabled.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "367f4161"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "i2v_super_noaudio_payload, i2v_super_noaudio_output, i2v_super_noaudio_model = create_payload(\"i2v_super_noaudio\", backend=\"vllm\")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1040,12 +1096,12 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "run_vllm_payload(i2v_super_noaudio_payload, i2v_super_noaudio_output, model=\"Cosmos3-Super\")\n"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1056,17 +1112,143 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
     "view_run(i2v_super_noaudio_output)\n"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9879d0c5",
+   "metadata": {},
+   "source": [
+    "# Super-4Step Examples\n",
+    "\n",
+    "The same audiovisual use cases for the Cosmos distilled model. This section is self-contained; you can run it without any of the sections above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00cc5f94",
+   "metadata": {},
+   "source": [
+    "## Super-4Step: Text to Image\n",
+    "\n",
+    "Cosmos3-Super-Text2Image-4Step generation is using the same structured JSON prompt.\n",
+    "\n",
+    "### Create Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
-   "outputs": []
+   "id": "b81c19a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t2i_distil_payload, t2i_distil_output, t2i_distil_model = create_payload(\"t2i_distil\", backend=\"vllm\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2382619",
+   "metadata": {},
+   "source": [
+    "### Run\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4055595",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_vllm_payload(t2i_distil_payload, t2i_distil_output, model=\"Cosmos3-Super-Text2Image-4Step\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7aeb0145",
+   "metadata": {},
+   "source": [
+    "### View Results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "167b53fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_run(t2i_distil_output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6633c3c",
+   "metadata": {},
+   "source": [
+    "## Super-4Step: Image to Video Without Audio\n",
+    "\n",
+    "Cosmos3-Super-Image2Video-4Step generation is using its paired image asset, with audio disabled.\n",
+    "\n",
+    "### Create Payload"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f64a8032",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "i2v_distil_payload, i2v_distil_output, i2v_distil_model = create_payload(\"i2v_distil\", backend=\"vllm\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a5f683c",
+   "metadata": {},
+   "source": [
+    "### Run\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5fbb8eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_vllm_payload(i2v_distil_payload, i2v_distil_output, model=\"Cosmos3-Super-Image2Video-4Step\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "327f8bf6",
+   "metadata": {},
+   "source": [
+    "### View Results\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45800e90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view_run(i2v_distil_output)"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "base",
+   "display_name": "scratch.adsridhar_other (3.12.3)",
    "language": "python",
    "name": "python3"
   },
@@ -1080,7 +1262,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/cookbooks/cosmos3/reasoner/README.md
+++ b/cookbooks/cosmos3/reasoner/README.md
@@ -75,7 +75,7 @@ The generated text is written to
 ### Notebook walkthrough
 
 [`run_with_cosmos_framework.ipynb`](./run_with_cosmos_framework.ipynb) is the full
-tutorial. It writes text and image smoke tests, then walks through image
+tutorial cover Nano, Super, Edge. It writes text and image smoke tests, then walks through image
 capability sections — detailed captioning, robot task planning, 2D grounding,
 describe-anything, and action-trajectory prompts — rendering the prompt, media
 input, model output, and any parsed boxes or trajectories together for review. It

--- a/cookbooks/cosmos3/reasoner/finetune/README.md
+++ b/cookbooks/cosmos3/reasoner/finetune/README.md
@@ -7,8 +7,9 @@ Supervised fine-tuning (SFT) of the Cosmos3 Reasoner on your own data. Tested on
 | Alignment SFT (LLaVA-OneVision) | `launch_sft_llava_ov.sh` | [lmms-lab/LLaVA-OneVision-Data](https://huggingface.co/datasets/lmms-lab/LLaVA-OneVision-Data) | Streams from HF; Cosmos3-Nano Reasoner checkpoint auto-prepared |
 | Physical-plausibility SFT (VideoPhy-2) | `launch_sft_videophy2_nano.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | 1–5 plausibility scoring; dataset + checkpoint auto-prepared |
 | Physical-plausibility SFT (VideoPhy-2, Cosmos3-Super) | `launch_sft_videophy2_super.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | Cosmos3-Super tier — Qwen3-VL-32B full fine-tune; dataset + checkpoint auto-prepared |
+| Physical-plausibility SFT (VideoPhy-2, Cosmos3-Edge) | `launch_sft_videophy2_edge.sh` | [videophysics/videophy2_train](https://huggingface.co/datasets/videophysics/videophy2_train) | Cosmos3-Edge tier — Nemotron-2B-Dense-VL (SigLIP2 tower, frozen); dataset auto-prepared; reasoner weights load directly from the (ungated) `nvidia/Cosmos3-Edge` snapshot |
 
-All use `[job].task = "vlm"`. The Nano recipes bootstrap from a Cosmos3-Nano Reasoner checkpoint; the Cosmos3-Super recipe bootstraps from a Cosmos3-Super Reasoner checkpoint (Cosmos3-Super LM merged onto the Qwen3-VL-32B visual tower). Both checkpoints are auto-prepared on first run.
+All use `[job].task = "vlm"`. The Nano recipes bootstrap from a Cosmos3-Nano Reasoner checkpoint; the Cosmos3-Super recipe bootstraps from a Cosmos3-Super Reasoner checkpoint (Cosmos3-Super LM merged onto the Qwen3-VL-32B visual tower); the Nano/Super checkpoints are auto-prepared on first run. The Cosmos3-Edge recipe loads its reasoner weights (Edge's own Nemotron-2B-Dense-VL LM + SigLIP2 reasoner tower) directly from the public `nvidia/Cosmos3-Edge` snapshot at startup — no conversion step.
 
 ## Prerequisites
 
@@ -28,9 +29,11 @@ bash launch_sft_llava_ov.sh          # alignment SFT; dataset streams from HF, b
 bash launch_sft_videophy2_nano.sh    # first run materializes VideoPhy-2 + builds the Cosmos3-Nano Reasoner checkpoint, then trains
 # or (Cosmos3-Super tier — Qwen3-VL-32B full fine-tune)
 bash launch_sft_videophy2_super.sh   # first run materializes VideoPhy-2 + builds the Cosmos3-Super Reasoner checkpoint, then trains
+# or (Cosmos3-Edge tier — Nemotron-2B-Dense-VL, 2B; also fits a 4-GPU node)
+bash launch_sft_videophy2_edge.sh    # first run materializes VideoPhy-2, then trains (reasoner weights load directly from nvidia/Cosmos3-Edge)
 ```
 
-The VideoPhy-2 download/convert steps are skipped once their outputs exist. Paths are fixed at the top of each script — edit them there to relocate data or checkpoints.
+The VideoPhy-2 download/convert steps are skipped once their outputs exist (Edge has no convert step — its weights stream from the HF cache). Paths are fixed at the top of each script — edit them there to relocate data or checkpoints.
 
 These recipes default to 8 GPUs. On a 4-GPU node (e.g. GB200×4), set `--nproc_per_node=4` on the `torchrun` line in the launch script.
 

--- a/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_edge.sh
+++ b/cookbooks/cosmos3/reasoner/finetune/launch_sft_videophy2_edge.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# Complete recipe: Reasoner physical-plausibility SFT on VideoPhy-2, Cosmos3-Edge
+# tier (Nemotron-2B-Dense-VL LM + SigLIP2 vision tower) (8x H100 or 4x GB200).
+# Run from this folder with the cosmos-framework venv active (see README):
+#   bash launch_sft_videophy2_edge.sh
+# It materializes the dataset, pre-fetches the model snapshot, and trains — in
+# order. Paths are fixed under this folder. Reasoner weights load directly from
+# the public nvidia/Cosmos3-Edge snapshot via the TOML's model_name — no converter step.
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+VIDEOPHYSICS_ROOT="$PWD/data/videophysics"
+
+# 1. Materialize the VideoPhy-2 dataset (skipped if present).
+if [[ ! -d "$VIDEOPHYSICS_ROOT/videophy2_train" ]]; then
+    python -m cosmos_framework.scripts.reasoner.prepare_videophy2_from_hf --out_root "$VIDEOPHYSICS_ROOT" --split both
+fi
+
+# 2. Pre-fetch the nvidia/Cosmos3-Edge snapshot into the HF cache (idempotent) so
+#    the multi-GB first download stays out of the multi-rank torchrun job.
+uvx hf@latest download nvidia/Cosmos3-Edge
+
+# 3. Train (FSDP full shard). VIDEOPHYSICS_ROOT is read from the environment.
+export VIDEOPHYSICS_ROOT
+# Edge is only 2B — on a 4-GPU node (e.g. GB200x4), set --nproc_per_node=4 instead.
+# The TOML defaults to flash_attention_2; if flash-attn is not installed, append
+# `-- model.config.policy.attn_implementation=sdpa` to the torchrun command.
+IMAGINAIRE_OUTPUT_ROOT="$PWD/outputs/train" torchrun --nproc_per_node=8 \
+    -m cosmos_framework.scripts.train --sft-toml="toml/sft_config/videophy2_sft_edge.toml"

--- a/cookbooks/cosmos3/reasoner/finetune/toml/sft_config/videophy2_sft_edge.toml
+++ b/cookbooks/cosmos3/reasoner/finetune/toml/sft_config/videophy2_sft_edge.toml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: OpenMDW-1.1
+
+# videophy2_sft_edge — VLM dialog SFT on VideoPhy-2 via CosmosDataLoader, on the
+# Cosmos3-Edge reasoner backbone (public nvidia/Cosmos3-Edge, model_type
+# cosmos3_edge). Base config = cosmos_framework/configs/base/reasoner/config.py
+# (selected by [job].task="vlm").
+#
+# Edge-tier counterpart of videophy2_sft_nano: same dataset + dataflow, but the
+# compact 2B Nemotron-2B-Dense-VL LM + SigLIP2 vision tower instead of Qwen3-VL-8B.
+# The SigLIP2 vision tower is frozen; the projector + LM train at a uniform 1e-6.
+# FSDP full-shard across every rank (data_parallel_shard_degree=-1, auto from
+# WORLD_SIZE) so it fits a 4-GPU (e.g. GB200x4) or 8-GPU allocation. Full fine-tune
+# (no LoRA).
+#
+# Dataset prep:
+#   python -m cosmos_framework.scripts.reasoner.prepare_videophy2_from_hf \
+#       --out_root $VIDEOPHYSICS_ROOT --split both
+#
+# Required env at launch: VIDEOPHYSICS_ROOT (read by the experiment Python).
+#
+# Example launch (from cookbooks/cosmos3/reasoner/finetune/):
+#   bash launch_sft_videophy2_edge.sh
+
+[job]
+task         = "vlm"
+experiment   = "videophy2_sft_edge"
+project      = "cosmos3"
+group        = "vlm_videophy2_sft"
+name         = "videophy2_sft_edge"
+wandb_mode   = "disabled"
+
+[model]
+# Edge delta vs nano: the "cosmos" adapter is Qwen3-VL-only and rejects the Edge
+# reasoner's (cosmos3_edge) mask. flash_attention_2 is ~14% faster than sdpa with
+# matching loss curves; set "sdpa" where flash-attn is not installed (portable fallback).
+attn_implementation = "flash_attention_2"
+precision           = "bfloat16"                         # was [model.parallelism].precision
+
+# Supplies arch/config/tokenizer and weights — loaded directly from the snapshot,
+# no converter step. Optional: set safetensors_path here to load local weights instead.
+[model.backbone]
+model_name = "nvidia/Cosmos3-Edge"
+
+[model.ema]
+enabled         = false
+rate            = 0.1
+iteration_shift = 0
+
+[model.parallelism]
+data_parallel_shard_degree      = -1                     # FSDP full shard, auto from WORLD_SIZE (4- or 8-GPU)
+data_parallel_replicate_degree  = 1
+context_parallel_shard_degree   = 1
+cfg_parallel_shard_degree       = 1
+
+[model.compile]
+enabled                         = false                  # was [model.parallelism].use_torch_compile
+compile_dynamic                 = true
+
+[model.activation_checkpointing]
+mode                = "full"
+save_ops_regex      = ["fmha"]
+preserve_rng_state  = true
+determinism_check   = "default"
+
+[optimizer]
+betas         = [0.9, 0.95]
+eps           = 1.0e-8
+fused         = true
+lr            = 1.0e-6
+weight_decay  = 0.1
+# Uniform 1e-6 across projector + LM + lm_head; the SigLIP2 vision tower is frozen
+# in the experiment (frozen_params regex), not via a per-part LR multiplier.
+
+[scheduler]
+cycle_lengths      = [50]
+f_max              = [1.0]
+f_min              = [0.1]
+f_start            = [0.05]
+verbosity_interval = 0
+warm_up_steps      = [5]
+
+[trainer]
+distributed_parallelism = "fsdp"
+grad_accum_iter         = 8
+logging_iter            = 1
+max_iter                = 50
+
+[trainer.callbacks.compile_tokenizer]
+compile_after_iterations = 3
+enabled                  = false
+
+[trainer.callbacks.grad_clip]
+clip_norm    = 1.0
+force_finite = false
+
+[checkpoint]
+keys_to_skip_loading = []
+load_path            = "???"
+save_iter            = 100
+
+[dataloader_train]
+# PATH_REMAPS["vlm"] routes these onto the CosmosDataLoader batcher
+# (max_batch_size / max_tokens).
+max_samples_per_batch = 1
+max_sequence_length   = 16000

--- a/cookbooks/cosmos3/reasoner/run_with_cosmos_framework.ipynb
+++ b/cookbooks/cosmos3/reasoner/run_with_cosmos_framework.ipynb
@@ -13,22 +13,22 @@
    "id": "f1bb4ce5",
    "metadata": {},
    "source": [
-    "# Cosmos3-Nano inference with Cosmos Framework\n",
+    "# Cosmos3 Reasoner inference with Cosmos Framework\n",
     "\n",
-    "This notebook runs Cosmos3 Reasoner Nano inference through the Cosmos Framework inference entrypoint:\n",
+    "This notebook runs Cosmos3 Reasoner inference through the Cosmos Framework inference entrypoint:\n",
     "\n",
     "```bash\n",
     "python -m cosmos_framework.scripts.inference\n",
     "```\n",
     "\n",
-    "It is intentionally written as a first-run cookbook: clone or locate the framework source, install dependencies from scratch, create working Reasoner input JSON files, run Nano text/image examples, and try several image-based capability prompts.\n",
+    "It is intentionally written as a first-run cookbook: clone or locate the framework source, install dependencies from scratch, create working Reasoner input JSON files, run Nano text/image examples, try several image-based capability prompts, and run the same text/image prompts on the Edge and Super models.\n",
     "\n",
     "Tested path from the audit:\n",
     "\n",
     "- Framework checkout: `packages/cosmos3`\n",
     "- Install command: `uv sync --all-extras --group=cu130-train`\n",
     "- Backend: Cosmos Framework / `cosmos_framework.scripts.inference`\n",
-    "- Model: `Cosmos3-Nano`\n"
+    "- Models: `Cosmos3-Nano` (default), `Cosmos3-Edge`, and `Cosmos3-Super`. All run the same Reasoner entrypoint; only `--checkpoint-path` differs. `Cosmos3-Super` needs a large-memory GPU (or multiple GPUs).\n"
    ]
   },
   {
@@ -1028,6 +1028,246 @@
     "    Path(os.environ[\"COSMOS3_OUTPUT_ROOT\"]) / \"cosmos_framework_trajectory_flower\",\n",
     ")\n",
     "draw_trajectory_if_present(sample, output_text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17ef8d8f",
+   "source": [
+    "## 15. Run Edge Text Inference\n",
+    "\n",
+    "`Cosmos3-Edge` runs the same Reasoner entrypoint as Nano. This runs it on the same text-only prompt used for Nano in step 7 — only `--checkpoint-path` changes; the input JSON (`nano_text.json`) is identical.\n",
+    "\n",
+    "Expected output file:\n",
+    "\n",
+    "```text\n",
+    "packages/cosmos3/outputs/cookbooks/cosmos3/reasoner/nano/cosmos_framework_edge_text/nano_text/reasoner_text.txt\n",
+    "```\n"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "86332615",
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "COSMOS_TRAINING=false CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" \\\n",
+    "MASTER_ADDR=\"$COSMOS3_MASTER_ADDR\" MASTER_PORT=\"$COSMOS3_NANO_TEXT_MASTER_PORT\" RANK=0 WORLD_SIZE=1 LOCAL_RANK=0 \\\n",
+    ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=latency \\\n",
+    "  -i \"$COSMOS3_INPUT_DIR/nano_text.json\" \\\n",
+    "  -o \"$COSMOS3_OUTPUT_ROOT/cosmos_framework_edge_text\" \\\n",
+    "  --checkpoint-path Cosmos3-Edge \\\n",
+    "  --seed=0 \\\n",
+    "  --benchmark\n"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "cfe10fea",
+   "source": [
+    "from pathlib import Path\n",
+    "import os, json\n",
+    "\n",
+    "output_root = Path(os.environ[\"COSMOS3_OUTPUT_ROOT\"])\n",
+    "text_path = output_root / \"cosmos_framework_edge_text\" / \"nano_text\" / \"reasoner_text.txt\"\n",
+    "benchmark_path = output_root / \"cosmos_framework_edge_text\" / \"benchmark.json\"\n",
+    "\n",
+    "print(text_path)\n",
+    "print(text_path.read_text())\n",
+    "if benchmark_path.exists():\n",
+    "    print(json.dumps(json.loads(benchmark_path.read_text()).get(\"average\", {}), indent=2))\n"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b25e7584",
+   "source": [
+    "## 16. Run Edge Image Inference\n",
+    "\n",
+    "This runs `Cosmos3-Edge` on the same image-conditioned Reasoner prompt used for Nano in step 8. Only `--checkpoint-path` changes; the input JSON (`nano_image.json`) is identical. The result cell renders the input image, text prompt, and model output side by side.\n",
+    "\n",
+    "Expected output file:\n",
+    "\n",
+    "```text\n",
+    "packages/cosmos3/outputs/cookbooks/cosmos3/reasoner/nano/cosmos_framework_edge_image/nano_image/reasoner_text.txt\n",
+    "```\n"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "cde5ff09",
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "COSMOS_TRAINING=false CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" \\\n",
+    "MASTER_ADDR=\"$COSMOS3_MASTER_ADDR\" MASTER_PORT=\"$COSMOS3_NANO_IMAGE_MASTER_PORT\" RANK=0 WORLD_SIZE=1 LOCAL_RANK=0 \\\n",
+    ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=latency \\\n",
+    "  -i \"$COSMOS3_INPUT_DIR/nano_image.json\" \\\n",
+    "  -o \"$COSMOS3_OUTPUT_ROOT/cosmos_framework_edge_image\" \\\n",
+    "  --checkpoint-path Cosmos3-Edge \\\n",
+    "  --seed=0 \\\n",
+    "  --benchmark\n"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "7376ed19",
+   "source": [
+    "from pathlib import Path\n",
+    "import os, json\n",
+    "\n",
+    "input_dir = Path(os.environ[\"COSMOS3_INPUT_DIR\"])\n",
+    "output_root = Path(os.environ[\"COSMOS3_OUTPUT_ROOT\"])\n",
+    "sample = json.loads((input_dir / \"nano_image.json\").read_text())\n",
+    "text_path = output_root / \"cosmos_framework_edge_image\" / \"nano_image\" / \"reasoner_text.txt\"\n",
+    "benchmark_path = output_root / \"cosmos_framework_edge_image\" / \"benchmark.json\"\n",
+    "output_text = text_path.read_text()\n",
+    "\n",
+    "show_reasoner_io(sample, output_text)\n",
+    "\n",
+    "print(\"output file:\", text_path)\n",
+    "if benchmark_path.exists():\n",
+    "    print(json.dumps(json.loads(benchmark_path.read_text()).get(\"average\", {}), indent=2))\n"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "super-text-section",
+   "metadata": {},
+   "source": [
+    "## 17. Run Super Text Inference\n",
+    "\n",
+    "`Cosmos3-Super` runs the same Reasoner entrypoint as Nano/Edge. This runs it on the same text-only prompt used for Nano in step 7 — only `--checkpoint-path` changes; the input JSON (`nano_text.json`) is identical. Super needs a large-memory GPU (or multiple GPUs).\n",
+    "\n",
+    "Expected output file:\n",
+    "\n",
+    "```text\n",
+    "packages/cosmos3/outputs/cookbooks/cosmos3/reasoner/nano/cosmos_framework_super_text/nano_text/reasoner_text.txt\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "super-text-run",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "COSMOS_TRAINING=false CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" \\\n",
+    "MASTER_ADDR=\"$COSMOS3_MASTER_ADDR\" MASTER_PORT=\"$COSMOS3_NANO_TEXT_MASTER_PORT\" RANK=0 WORLD_SIZE=1 LOCAL_RANK=0 \\\n",
+    ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=latency \\\n",
+    "  -i \"$COSMOS3_INPUT_DIR/nano_text.json\" \\\n",
+    "  -o \"$COSMOS3_OUTPUT_ROOT/cosmos_framework_super_text\" \\\n",
+    "  --checkpoint-path Cosmos3-Super \\\n",
+    "  --seed=0 \\\n",
+    "  --benchmark\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "super-text-display",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os, json\n",
+    "\n",
+    "output_root = Path(os.environ[\"COSMOS3_OUTPUT_ROOT\"])\n",
+    "text_path = output_root / \"cosmos_framework_super_text\" / \"nano_text\" / \"reasoner_text.txt\"\n",
+    "benchmark_path = output_root / \"cosmos_framework_super_text\" / \"benchmark.json\"\n",
+    "\n",
+    "print(text_path)\n",
+    "print(text_path.read_text())\n",
+    "if benchmark_path.exists():\n",
+    "    print(json.dumps(json.loads(benchmark_path.read_text()).get(\"average\", {}), indent=2))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "super-image-section",
+   "metadata": {},
+   "source": [
+    "## 18. Run Super Image Inference\n",
+    "\n",
+    "This runs `Cosmos3-Super` on the same image-conditioned Reasoner prompt used for Nano in step 8. Only `--checkpoint-path` changes; the input JSON (`nano_image.json`) is identical. The result cell renders the input image, text prompt, and model output side by side.\n",
+    "\n",
+    "Expected output file:\n",
+    "\n",
+    "```text\n",
+    "packages/cosmos3/outputs/cookbooks/cosmos3/reasoner/nano/cosmos_framework_super_image/nano_image/reasoner_text.txt\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "super-image-run",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "cd \"$COSMOS3_REPO\"\n",
+    "COSMOS_TRAINING=false CUDA_VISIBLE_DEVICES=\"$CUDA_VISIBLE_DEVICES\" \\\n",
+    "MASTER_ADDR=\"$COSMOS3_MASTER_ADDR\" MASTER_PORT=\"$COSMOS3_NANO_IMAGE_MASTER_PORT\" RANK=0 WORLD_SIZE=1 LOCAL_RANK=0 \\\n",
+    ".venv/bin/python -m cosmos_framework.scripts.inference \\\n",
+    "  --parallelism-preset=latency \\\n",
+    "  -i \"$COSMOS3_INPUT_DIR/nano_image.json\" \\\n",
+    "  -o \"$COSMOS3_OUTPUT_ROOT/cosmos_framework_super_image\" \\\n",
+    "  --checkpoint-path Cosmos3-Super \\\n",
+    "  --seed=0 \\\n",
+    "  --benchmark\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "super-image-display",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import os, json\n",
+    "\n",
+    "input_dir = Path(os.environ[\"COSMOS3_INPUT_DIR\"])\n",
+    "output_root = Path(os.environ[\"COSMOS3_OUTPUT_ROOT\"])\n",
+    "sample = json.loads((input_dir / \"nano_image.json\").read_text())\n",
+    "text_path = output_root / \"cosmos_framework_super_image\" / \"nano_image\" / \"reasoner_text.txt\"\n",
+    "benchmark_path = output_root / \"cosmos_framework_super_image\" / \"benchmark.json\"\n",
+    "output_text = text_path.read_text()\n",
+    "\n",
+    "show_reasoner_io(sample, output_text)\n",
+    "\n",
+    "print(\"output file:\", text_path)\n",
+    "if benchmark_path.exists():\n",
+    "    print(json.dumps(json.loads(benchmark_path.read_text()).get(\"average\", {}), indent=2))\n"
    ]
   }
  ],

--- a/cookbooks/cosmos3/reasoner/run_with_vllm.ipynb
+++ b/cookbooks/cosmos3/reasoner/run_with_vllm.ipynb
@@ -5,48 +5,21 @@
    "id": "license-header",
    "metadata": {},
    "source": [
-    "<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\nSPDX-License-Identifier: OpenMDW-1.1 -->"
+    "<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
+    "SPDX-License-Identifier: OpenMDW-1.1 -->"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "b4e72c4a",
    "metadata": {},
-   "source": [
-    "### Cosmos3-Super inference with vLLM\n",
-    "\n",
-    "This notebook:\n",
-    "1. Sets up an isolated environment with native Cosmos3 support in `vllm>=0.23.0`.\n",
-    "2. Launches an OpenAI-compatible vLLM server in the background.\n",
-    "3. Sends image and video requests with the `openai` client.\n",
-    "\n",
-    "`Cosmos3-Super` is larger than `Cosmos3-Nano` and is served with tensor parallelism across 4 GPUs."
-   ]
+   "source": "# Cosmos3 Reasoner inference with vLLM\n\nThis notebook serves the Cosmos3 Reasoner with an OpenAI-compatible **vLLM** server,\nusing the prebuilt `vllm/vllm-openai:cosmos3` Docker image. It:\n\n1. Pulls the vLLM Docker image and installs the client dependencies.\n2. Launches an OpenAI-compatible server for the model tier you choose.\n3. Sends image and video reasoning requests with the `openai` client.\n\nThe notebook serves the `nvidia/Cosmos3-Super` tier across 4 GPUs with tensor parallelism.\nThe query examples in the final section resolve the served model dynamically."
   },
   {
    "cell_type": "markdown",
    "id": "3f8b961e",
    "metadata": {},
-   "source": [
-    "## 1. Environment setup\n",
-    "\n",
-    "Create a local `.venv` and install a vLLM release with native Cosmos3 support. This can take a few minutes.\n",
-    "\n",
-    "The install below pins a CUDA build of `torch`/`vllm`, and it must match your NVIDIA driver:\n",
-    "\n",
-    "| Driver CUDA | Install |\n",
-    "| --- | --- |\n",
-    "| 13.x | `--torch-backend=cu130 \"vllm>=0.23.0\"` (default below) |\n",
-    "| 12.x | `--torch-backend=cu128 \"vllm>=0.23.0\"` if a compatible wheel is available |\n",
-    "\n",
-    "`cu130` wheels need a CUDA 13 driver; on a CUDA 12.x driver use a compatible `cu128` wheel instead, or `torch.cuda.is_available()` returns `False` and the server falls back/fails. vLLM does not publish a wheel for every CUDA minor version, so `--torch-backend=auto` is not reliable here.\n",
-    "\n",
-    "The model is gated on Hugging Face, so log in once before launching (a token with access is required):\n",
-    "\n",
-    "```bash\n",
-    "hf auth login\n",
-    "```"
-   ]
+   "source": "## 1. Setup\n\nServing runs entirely in Docker, so no local Python environment is required for the model.\nYou need:\n\n- Docker with the NVIDIA Container Toolkit (`--runtime nvidia` / `--gpus`).\n- The `vllm/vllm-openai:cosmos3` image, which ships native Cosmos3 Reasoner support\n  (vLLM ≥ 0.23.0). A cell below pulls it (~19 GB on first run).\n\nThe Reasoner checkpoints are gated on Hugging Face. After running the setup cells below,\nauthenticate with a token that has access — the launch cells mount `~/.cache/huggingface`\ninto the container so the token and downloaded weights are reused:\n\n```bash\nhf auth login\n```"
   },
   {
    "cell_type": "code",
@@ -98,38 +71,33 @@
   },
   {
    "cell_type": "code",
+   "id": "47bb9a58",
+   "source": "# Client-side dependencies for this notebook (not the model): the OpenAI client to\n# send requests, and the Hugging Face CLI used by the `hf auth login` step above.\n%pip install -q \"openai>=1.0\" pillow \"huggingface_hub[cli]\"",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "id": "55d4497b",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "if [ -x .venv/bin/python ]; then\n",
-    "  echo \"Using existing venv: $PWD/.venv\"\n",
-    "else\n",
-    "  uv venv --python 3.13 --seed --managed-python\n",
-    "fi\n",
-    "\n",
-    "uv pip install --python .venv/bin/python --torch-backend=cu130 \\\n",
-    "  \"vllm>=0.23.0\" \\\n",
-    "  \"openai>=1.0\"\n"
-   ]
+   "source": "%%bash\nset -euo pipefail\n# Pull the prebuilt vLLM image with native Cosmos3 Reasoner support (~19 GB; first run only).\ndocker pull vllm/vllm-openai:cosmos3"
   },
   {
    "cell_type": "markdown",
    "id": "7fc6b07a",
    "metadata": {},
-   "source": [
-    "## 2. Launch the vLLM server\n",
-    "\n",
-    "Start the OpenAI-compatible server in the background (output goes to `vllm_server.log`). The first start compiles CUDA graphs and can take several minutes. The next cell waits for server readiness automatically while streaming new log lines.\n",
-    "\n",
-    "`Cosmos3-Super` is tested with 4 GPUs: it is launched with `--tensor-parallel-size 4` and `CUDA_VISIBLE_DEVICES=0,1,2,3`.\n"
-   ]
+   "source": "## 2. Launch a vLLM server\n\nRun the Super tier below. It uses the container name `cosmos3-reasoner-vllm` and publishes\nthe container's port 8000 to host port **8001**, which matches the endpoint the query cells use.\n\nThe first start downloads the weights and compiles CUDA graphs and can take several\nminutes; the readiness cell below polls `/health` and waits automatically."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb382fed",
+   "source": "### Cosmos3-Super inference with vLLM\n\n`Cosmos3-Super` is the larger tier, served across **4 GPUs** with `--tensor-parallel-size 4`.\nRun this cell to launch the server.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -137,29 +105,13 @@
    "id": "d53a0ead",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "%%bash\n",
-    "# `setsid` is only needed in Jupyter: it detaches the server into its own session so it\n",
-    "# survives kernel interrupts/restarts. In a plain terminal you can drop `setsid` (and `& disown`)\n",
-    "# and just run `vllm serve ...`.\n",
-    "# Output goes to vllm_server.log (watched by the next cell).\n",
-    "# Cosmos3-Super is served across 4 GPUs (tensor-parallel-size 4).\n",
-    ": \"${COSMOS3_MEDIA_ROOT:=$(dirname \"$(pwd)\")}\"\n",
-    "export TMPDIR=\"/tmp/${USER:-vllm}-vllm\"\n",
-    "export VLLM_PORT=\"${VLLM_PORT:-8001}\"\n",
-    "export VLLM_LOG_FILE=\"${VLLM_LOG_FILE:-vllm_server.log}\"\n",
-    "mkdir -p \"$TMPDIR\"\n",
-    "CUDA_VISIBLE_DEVICES=0,1,2,3 \\\n",
-    "setsid .venv/bin/vllm serve nvidia/Cosmos3-Super \\\n",
-    "  --tensor-parallel-size 4 \\\n",
-    "  --mm-encoder-tp-mode data \\\n",
-    "  --async-scheduling \\\n",
-    "  --allowed-local-media-path \"$COSMOS3_MEDIA_ROOT\" \\\n",
-    "  --media-io-kwargs '{\"video\": {\"num_frames\": -1}}' \\\n",
-    "  --port \"$VLLM_PORT\" > \"$VLLM_LOG_FILE\" 2>&1 &\n",
-    "disown\n",
-    "echo \"Server launching in background; watch $VLLM_LOG_FILE\"\n"
-   ]
+   "source": "%%bash\nset -euo pipefail\n: \"${COSMOS_ROOT:?run the setup cell first}\"\n: \"${COSMOS3_MEDIA_ROOT:?run the setup cell first}\"\nCONTAINER=cosmos3-reasoner-vllm\n\n# Remove any existing server first.\ndocker rm -f \"$CONTAINER\" 2>/dev/null || true\ndocker run -d --name \"$CONTAINER\" \\\n  --runtime nvidia --gpus all \\\n  -e HF_HOME=/root/.cache/huggingface \\\n  -v \"$HOME/.cache/huggingface:/root/.cache/huggingface\" \\\n  -v \"$COSMOS_ROOT:$COSMOS_ROOT\" \\\n  -p 8001:8000 --ipc=host \\\n  vllm/vllm-openai:cosmos3 \\\n  nvidia/Cosmos3-Super \\\n    --tensor-parallel-size 4 \\\n    --mm-encoder-tp-mode data \\\n    --async-scheduling \\\n    --allowed-local-media-path \"$COSMOS3_MEDIA_ROOT\" \\\n    --media-io-kwargs '{\"video\": {\"num_frames\": -1}}' \\\n    --port 8000\necho \"Cosmos3-Super starting in container '$CONTAINER' — run the readiness cell next.\""
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2681425",
+   "source": "### Wait for the server to be ready\n\nRun this after launching either tier. It streams the container log and polls `/health`\nuntil the server is ready, allowing up to 30 minutes on the first run while the weights\ndownload and CUDA graphs compile.",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -169,38 +121,7 @@
     "scrolled": true
    },
    "outputs": [],
-   "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "PORT=\"${VLLM_PORT:-8001}\"\n",
-    "LOG_FILE=\"${VLLM_LOG_FILE:-vllm_server.log}\"\n",
-    "\n",
-    "echo \"Waiting for vLLM server on port ${PORT}...\"\n",
-    "touch \"$LOG_FILE\"\n",
-    "\n",
-    "LAST_LINE=0\n",
-    "\n",
-    "for i in $(seq 1 1800); do\n",
-    "  TOTAL_LINES=$(wc -l < \"$LOG_FILE\" || echo 0)\n",
-    "\n",
-    "  if [ \"$TOTAL_LINES\" -gt \"$LAST_LINE\" ]; then\n",
-    "    sed -n \"$((LAST_LINE + 1)),$TOTAL_LINES p\" \"$LOG_FILE\"\n",
-    "    LAST_LINE=\"$TOTAL_LINES\"\n",
-    "  fi\n",
-    "\n",
-    "  if curl -fsS \"http://127.0.0.1:${PORT}/health\" >/dev/null 2>&1; then\n",
-    "    echo \"vLLM server is ready.\"\n",
-    "    exit 0\n",
-    "  fi\n",
-    "\n",
-    "  sleep 1\n",
-    "done\n",
-    "\n",
-    "echo \"Timed out waiting for vLLM server.\"\n",
-    "tail -n 120 \"$LOG_FILE\"\n",
-    "exit 1\n"
-   ]
+   "source": "%%bash\nset -uo pipefail\nPORT=\"${VLLM_PORT:-8001}\"\nCONTAINER=cosmos3-reasoner-vllm\n\necho \"Streaming server logs; waiting for http://127.0.0.1:${PORT}/health ...\"\ndocker logs -f \"$CONTAINER\" 2>&1 &\nLOGPID=$!\n\nfor i in $(seq 1 1800); do\n  if curl -fsS \"http://127.0.0.1:${PORT}/health\" >/dev/null 2>&1; then\n    echo; echo \"vLLM server is ready.\"\n    kill \"$LOGPID\" 2>/dev/null || true\n    exit 0\n  fi\n  if ! docker ps -q -f \"name=^${CONTAINER}$\" | grep -q .; then\n    echo; echo \"Container exited early (see logs above).\"\n    kill \"$LOGPID\" 2>/dev/null || true\n    exit 1\n  fi\n  sleep 2\ndone\n\nkill \"$LOGPID\" 2>/dev/null || true\necho \"Timed out waiting for vLLM server.\"\nexit 1"
   },
   {
    "cell_type": "markdown",
@@ -796,69 +717,7 @@
     "scrolled": true
    },
    "outputs": [],
-   "source": [
-    "import json\n",
-    "import re\n",
-    "import openai\n",
-    "from pathlib import Path\n",
-    "from PIL import Image as PILImage, ImageDraw\n",
-    "from IPython.display import display\n",
-    "\n",
-    "client = openai.OpenAI(api_key=\"EMPTY\", base_url=\"http://localhost:8001/v1\")\n",
-    "MODEL = client.models.list().data[0].id\n",
-    "\n",
-    "image_path = str(asset_path(\"grounding_2d.png\"))\n",
-    "image_url = Path(image_path).resolve().as_uri()   # file:// URL for the model\n",
-    "\n",
-    "response = client.chat.completions.create(\n",
-    "    model=MODEL,\n",
-    "    messages=[\n",
-    "        {\n",
-    "            \"role\": \"user\",\n",
-    "            \"content\": [\n",
-    "                {\"type\": \"image_url\", \"image_url\": {\"url\": image_url}},\n",
-    "                {\"type\": \"text\", \"text\": \"Locate the accurate bounding box of the load as a whole. Return a json.\"},\n",
-    "            ],\n",
-    "        }\n",
-    "    ],\n",
-    "    max_tokens=4096,\n",
-    "    seed=0,\n",
-    ")\n",
-    "out = response.choices[0].message.content\n",
-    "print(out)\n",
-    "\n",
-    "\n",
-    "def parse_boxes(text):\n",
-    "    \"\"\"Pull a JSON array/object of boxes out of the model text (handles ``` fences).\"\"\"\n",
-    "    text = text.strip()\n",
-    "    text = re.sub(r\"^```(?:json)?|```$\", \"\", text, flags=re.MULTILINE).strip()\n",
-    "    m = re.search(r\"\\[.*\\]|\\{.*\\}\", text, re.DOTALL)\n",
-    "    data = json.loads(m.group(0) if m else text)\n",
-    "    return data if isinstance(data, list) else [data]\n",
-    "\n",
-    "\n",
-    "# Draw boxes; coords are normalized to 0-1000\n",
-    "img = PILImage.open(image_path).convert(\"RGB\")\n",
-    "W, H = img.size\n",
-    "draw = ImageDraw.Draw(img)\n",
-    "\n",
-    "for obj in parse_boxes(out):\n",
-    "    box = obj.get(\"bbox_2d\") or obj.get(\"bbox\") or obj.get(\"box\")\n",
-    "    if not box:\n",
-    "        continue\n",
-    "    x1, y1, x2, y2 = box\n",
-    "    x1, x2 = x1 / 1000 * W, x2 / 1000 * W\n",
-    "    y1, y2 = y1 / 1000 * H, y2 / 1000 * H\n",
-    "    draw.rectangle([x1, y1, x2, y2], outline=\"red\", width=3)\n",
-    "    label = obj.get(\"label\") or obj.get(\"name\")\n",
-    "    if label:\n",
-    "        draw.text((x1, max(0, y1 - 12)), str(label), fill=\"red\")\n",
-    "\n",
-    "# Display scaled down so a large image fits the cell\n",
-    "preview = img.copy()\n",
-    "preview.thumbnail((768, 768))\n",
-    "display(preview)"
-   ]
+   "source": "import json\nimport re\nimport openai\nfrom pathlib import Path\nfrom PIL import Image as PILImage, ImageDraw\nfrom IPython.display import display\n\nclient = openai.OpenAI(api_key=\"EMPTY\", base_url=\"http://localhost:8001/v1\")\nMODEL = client.models.list().data[0].id\n\nimage_path = str(asset_path(\"grounding_2d.png\"))\nimage_url = Path(image_path).resolve().as_uri()   # file:// URL for the model\n\nresponse = client.chat.completions.create(\n    model=MODEL,\n    messages=[\n        {\n            \"role\": \"user\",\n            \"content\": [\n                {\"type\": \"image_url\", \"image_url\": {\"url\": image_url}},\n                {\"type\": \"text\", \"text\": \"Locate the accurate bounding box of the load as a whole. Return a json.\"},\n            ],\n        }\n    ],\n    max_tokens=4096,\n    seed=0,\n)\nout = response.choices[0].message.content\nprint(out)\n\n\ndef parse_boxes(text):\n    \"\"\"Extract JSON box objects from the model text.\n\n    The Reasoner replies in free-form text, so this tolerates a ``<think>`` block,\n    ``` fences, and any prose after the JSON (which varies between runs).\n    \"\"\"\n    if \"</think>\" in text:\n        text = text.split(\"</think>\")[-1]\n    text = re.sub(r\"```(?:json)?|```\", \"\", text).strip()\n    starts = [i for i in (text.find(\"[\"), text.find(\"{\")) if i != -1]\n    if not starts:\n        return []\n    data, _ = json.JSONDecoder().raw_decode(text[min(starts):])\n    return data if isinstance(data, list) else [data]\n\n\ndef box_coords(obj):\n    \"\"\"Return ``[x1, y1, x2, y2]`` from the varied shapes the model emits.\"\"\"\n    vals = obj if isinstance(obj, (list, tuple)) else (\n        obj.get(\"bbox_2d\") or obj.get(\"bbox\") or obj.get(\"box\") or obj.get(\"bounding_box\")\n    )\n    if vals is None and isinstance(obj, dict) and all(k in obj for k in (\"x1\", \"y1\", \"x2\")):\n        vals = [obj[\"x1\"], obj[\"y1\"], obj[\"x2\"], obj.get(\"y2\", obj.get(\"y3\"))]\n    if not vals or len(vals) < 4:\n        return None\n    try:\n        return [float(v) for v in vals[:4]]\n    except (TypeError, ValueError):\n        return None\n\n\n# Draw boxes; coords are normalized to 0-1000\nimg = PILImage.open(image_path).convert(\"RGB\")\nW, H = img.size\ndraw = ImageDraw.Draw(img)\n\nfor obj in parse_boxes(out):\n    box = box_coords(obj)\n    if not box:\n        continue\n    x1, y1, x2, y2 = box\n    x1, x2 = x1 / 1000 * W, x2 / 1000 * W\n    y1, y2 = y1 / 1000 * H, y2 / 1000 * H\n    draw.rectangle([x1, y1, x2, y2], outline=\"red\", width=3)\n    label = (obj.get(\"label\") or obj.get(\"name\")) if isinstance(obj, dict) else None\n    if label:\n        draw.text((x1, max(0, y1 - 12)), str(label), fill=\"red\")\n\n# Display scaled down so a large image fits the cell\npreview = img.copy()\npreview.thumbnail((768, 768))\ndisplay(preview)"
   },
   {
    "cell_type": "markdown",
@@ -1235,12 +1094,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bbaff2a2",
+   "source": "## 4. Shut down the server\n\nWhen you are finished, stop and remove the container to free the GPUs and host port.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "89735fc4-5c42-410c-8697-878120d08f68",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": "!docker rm -f cosmos3-reasoner-vllm"
   }
  ],
  "metadata": {

--- a/inference_benchmarks.md
+++ b/inference_benchmarks.md
@@ -1,11 +1,14 @@
 # Inference Benchmarks
 
-These tables collect inference benchmarks for Cosmos3. **Generator** sections measure diffusion-path latency (image and video generation via i2v, t2i, and t2v) across PyTorch, vLLM-Omni, and Diffusers. The **Reasoner** section measures VLM serving metrics (TTFT, request latency, throughput) for text outputs from vision and text inputs via vLLM.
+These tables collect inference benchmarks for Cosmos3. **Generator** sections measure visual-generation and world-model latency across PyTorch, vLLM-Omni, Diffusers, and NIM, including image and video generation, forward and inverse dynamics, and policy generation. **Reasoner** sections measure VLM serving and token-generation performance for text, image, and video inputs through vLLM and Hugging Face Transformers.
 
 Generator results are published incrementally from internal benchmark runs. **Empty cells mean that combination has not been measured yet** — not that it is unsupported. See the notes under each table for workload details and data-source definitions.
 
 ## Table of Contents
 
+- [Cosmos3-Edge Generator](#cosmos3-edge-generator)
+  - [vLLM-Omni](#vllm-omni)
+  - [PyTorch](#pytorch)
 - [Cosmos3-Nano Generator](#cosmos3-nano-generator)
   - [Text-to-Video (t2v)](#text-to-video-t2v)
   - [Image-to-Video (i2v)](#image-to-video-i2v)
@@ -14,6 +17,10 @@ Generator results are published incrementally from internal benchmark runs. **Em
   - [Text-to-Video (t2v)](#text-to-video-t2v-1)
   - [Image-to-Video (i2v)](#image-to-video-i2v-1)
   - [Text-to-Image (t2i)](#text-to-image-t2i-1)
+- [Cosmos3-Edge Reasoner](#cosmos3-edge-reasoner)
+  - [RTX PRO 4500 Blackwell Server Edition](#rtx-pro-4500-blackwell-server-edition)
+  - [RTX PRO 6000 Blackwell Server Edition](#rtx-pro-6000-blackwell-server-edition)
+  - [Embedded-Platform Eager Transformers](#embedded-platform-eager-transformers)
 - [Cosmos3-Nano Reasoner](#cosmos3-nano-reasoner)
   - [RTX PRO 6000 Blackwell](#rtx-pro-6000-blackwell)
   - [H20](#h20)
@@ -31,6 +38,51 @@ Generator results are published incrementally from internal benchmark runs. **Em
   - [H200 141GB HBM3](#h200-141gb-hbm3-1)
   - [B200](#b200-1)
   - [B300](#b300-1)
+
+## Cosmos3-Edge Generator
+
+These tables report **Cosmos3-Edge** Generator latency in seconds for **image-to-video**, **forward dynamics**, **inverse dynamics**, and **DROID policy generation**. Measurements use one GPU or one integrated computing platform. Lower latency is better, and empty cells indicate that a run has not been completed.
+
+Unless otherwise noted, visual-generation benchmarks use **480p resolution**, and image-to-video benchmarks generate **189 frames**. vLLM-Omni values report end-to-end latency, while PyTorch values report average generation latency.
+
+### vLLM-Omni
+
+| GPU or Platform | Image-to-Video | Forward Dynamics | Inverse Dynamics | Policy DROID |
+|---|---:|---:|---:|---:|
+| B200 SXM 192 GB |  | 2.44 | 3.98 | 0.99 |
+| H100 SXM 80 GB | 27.64 | 3.91 | 5.60 | 1.41 |
+| H100 NVL 96 GB | 35.60 | 4.73 | 6.39 | 1.37 |
+| H20 SXM 96 GB | 108.16 | 12.77 | 15.49 | 3.41 |
+| RTX PRO 6000 Blackwell Server Edition | 36.29 | 5.65 | 7.46 | 1.87 |
+| DGX Station | 12.17 | 4.33 | 6.34 | 8.11 |
+| DGX Spark | 165.96 | 26.43 | 30.86 | 7.66 |
+| Jetson AGX Thor T5000, 128 GB, MAXN | 137.50 | 6.05 | 7.19 | 6.32 |
+| Jetson T3000, 32 GB, 1100 MHz | 194.76 | 8.67 | 10.25 | 8.63 |
+| Jetson T2000, 16 GB, 702 MHz, THOR_NANO | 101.20 |  |  |  |
+
+### PyTorch
+
+| GPU or Platform | Image-to-Video | Forward Dynamics | Inverse Dynamics | Policy DROID |
+|---|---:|---:|---:|---:|
+| H100 SXM 80 GB | 23.92 | 3.69 | 3.56 | 1.25 |
+| H100 NVL 96 GB | 32.24 | 4.64 | 4.52 | 1.28 |
+| H20 SXM 96 GB | 97.51 | 12.78 | 12.64 | 2.92 |
+| RTX PRO 6000 Blackwell Server Edition | 38.98 | 5.26 | 5.66 | 1.32 |
+| DGX Station | 10.57 | 2.16 | 2.26 | 1.30 |
+| DGX Spark | 179.80 | 24.59 | 26.76 | 5.44 |
+| Jetson AGX Thor T5000, 128 GB, MAXN | 153.00 |  |  |  |
+| Jetson T3000, 32 GB, 1100 MHz | 227.80 |  |  |  |
+
+<sub>Notes:
+1. All measurements use one GPU or one integrated computing platform.
+2. Values are average end-to-end or generation latency in seconds; lower is better.
+3. Unless otherwise specified, visual-generation measurements use **480p resolution**.
+4. Image-to-video measurements generate **189 output frames**.
+5. Jetson AGX Thor T5000 and Jetson T3000 visual-generation measurements use **832 × 480** resolution.
+6. Jetson T2000 visual-generation measurements use **448 × 256** resolution and therefore should not be compared directly with the 480p results. Its image-to-video values are warm-run measurements generating 189 frames.
+7. PyTorch values report average generation latency rather than diffusion-only latency.
+8. Datacenter and enterprise forward- and inverse-dynamics results use the autonomous-driving (`AV`) configuration.
+9. Jetson AGX Thor T5000 and Jetson T3000 forward-dynamics, inverse-dynamics, and policy measurements use the DROID configuration with action chunk `[16, 8]`.</sub>
 
 ## Cosmos3-Nano Generator
 
@@ -267,6 +319,125 @@ As with Nano, four engines are tracked: **PyTorch** (OSS generation/sampling tim
 5. At 256p, multi-GPU configurations on B300 may underperform single-GPU due to small-workload TP overhead; single-GPU is recommended at this resolution.
 6. PyTorch numbers report average generation (sampling) time from OSS inference benchmarking.
 7. NIM numbers use latency profiles with FP8 precision and report end-to-end `Request Latency s`, including request processing, video generation, output encoding, and returning the response.</sub>
+
+## Cosmos3-Edge Reasoner
+
+These tables report **Cosmos3-Edge** reasoner serving performance through **vLLM**. Unlike the Generator benchmarks, Reasoner workloads produce autoregressively generated text and measure time to first token (TTFT), end-to-end request latency, request throughput, and output-token throughput. Lower is better for latency metrics; higher is better for throughput.
+
+All vLLM runs use the **`nvidia/Cosmos3-Edge`** checkpoint with one GPU. Metrics were collected at client-side concurrency levels of 1, 64, 128, and 256. Each GPU section contains four workload tables that vary input sequence length, output sequence length, and video frame rate.
+
+### RTX PRO 4500 Blackwell Server Edition
+
+#### Input 50 / Output 1 / Video 1 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 165.79 | 8817.33 | 14702.20 | 29482.39 |
+| Request Latency (ms) | 165.79 | 8817.33 | 14702.20 | 29482.39 |
+| Request Count (requests) | 50 | 320 | 256 | 512 |
+| Request Throughput (Req/s) | 6.00 | 6.55 | 6.55 | 6.52 |
+| Output Token Throughput (Tok/s) | 6.00 | 6.55 | 6.55 | 6.52 |
+
+#### Input 50 / Output 1 / Video 2 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 371.67 | 20375.98 | 33812.45 | 68201.55 |
+| Request Latency (ms) | 371.67 | 20375.98 | 33812.45 | 68201.55 |
+| Request Count (requests) | 50 | 313 | 249 | 492 |
+| Request Throughput (Req/s) | 2.68 | 2.77 | 2.76 | 2.71 |
+| Output Token Throughput (Tok/s) | 2.68 | 2.77 | 2.76 | 2.71 |
+
+#### Input 50 / Output 100 / Video 1 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 166.86 | 6900.90 | 19625.83 | 45729.55 |
+| Request Latency (ms) | 764.15 | 16667.01 | 29196.84 | 55749.62 |
+| Request Count (requests) | 50 | 320 | 256 | 512 |
+| Request Throughput (Req/s) | 1.31 | 3.73 | 3.74 | 3.70 |
+| Output Token Throughput (Tok/s) | 130.63 | 372.40 | 373.98 | 369.87 |
+
+#### Input 50 / Output 100 / Video 2 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 374.93 | 23526.65 | 47550.99 | 101553.31 |
+| Request Latency (ms) | 1041.29 | 33712.54 | 57641.53 | 111895.20 |
+| Request Count (requests) | 50 | 320 | 256 | 512 |
+| Request Throughput (Req/s) | 0.96 | 1.79 | 1.79 | 1.78 |
+| Output Token Throughput (Tok/s) | 95.74 | 178.73 | 178.89 | 178.15 |
+
+### RTX PRO 6000 Blackwell Server Edition
+
+#### Input 50 / Output 1 / Video 1 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 141.99 | 3213.91 | 5384.51 | 10792.72 |
+| Request Latency (ms) | 141.99 | 3213.91 | 5384.51 | 10792.72 |
+| Request Count (requests) | 50 | 320 | 254 | 512 |
+| Request Throughput (Req/s) | 6.96 | 18.00 | 17.95 | 17.89 |
+| Output Token Throughput (Tok/s) | 6.96 | 18.00 | 17.95 | 17.89 |
+
+#### Input 50 / Output 1 / Video 2 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 239.86 | 7483.22 | 12552.69 | 25259.11 |
+| Request Latency (ms) | 239.86 | 7483.22 | 12552.69 | 25259.11 |
+| Request Count (requests) | 49 | 303 | 249 | 491 |
+| Request Throughput (Req/s) | 4.06 | 7.28 | 7.49 | 7.34 |
+| Output Token Throughput (Tok/s) | 4.06 | 7.28 | 7.49 | 7.34 |
+
+#### Input 50 / Output 100 / Video 1 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 138.74 | 943.46 | 2680.17 | 11599.63 |
+| Request Latency (ms) | 503.44 | 6188.90 | 13022.07 | 26388.89 |
+| Request Count (requests) | 50 | 320 | 256 | 512 |
+| Request Throughput (Req/s) | 1.98 | 10.27 | 9.57 | 8.95 |
+| Output Token Throughput (Tok/s) | 197.75 | 1026.14 | 956.47 | 893.91 |
+
+#### Input 50 / Output 100 / Video 2 FPS
+
+| Metric | Concurrency 1 | Concurrency 64 | Concurrency 128 | Concurrency 256 |
+|---|---:|---:|---:|---:|
+| Time To First Token (ms) | 239.24 | 1798.96 | 11644.84 | 33293.32 |
+| Request Latency (ms) | 638.71 | 13599.89 | 26299.90 | 49165.91 |
+| Request Count (requests) | 50 | 320 | 256 | 512 |
+| Request Throughput (Req/s) | 1.56 | 4.66 | 4.50 | 4.45 |
+| Output Token Throughput (Tok/s) | 155.93 | 465.28 | 449.57 | 444.17 |
+
+### Embedded-Platform Eager Transformers
+
+These preliminary measurements use raw Hugging Face Transformers in eager mode rather than vLLM. They are presented separately because their runtime, workloads, and metric definitions differ from the vLLM serving benchmarks above.
+
+| Board | Specification | Input | Prompt Tokens | Prefill Throughput | Prefill Latency | Decode Throughput | End-to-End Latency |
+|---|---|---|---:|---:|---:|---:|---:|
+| Jetson AGX Thor T5000 | 128 GB / MAXN | Text | 1705 | 8717 Tok/s | 0.20 s | 37.3 Tok/s | 3.60 s |
+| Jetson AGX Thor T5000 | 128 GB / MAXN | Image | 911 | 4845 Tok/s | 0.19 s | 42.6 Tok/s | 3.17 s |
+| Jetson AGX Thor T5000 | 128 GB / MAXN | Video | 1263 | 6032 Tok/s | 0.21 s | 41.8 Tok/s | 3.25 s |
+| Jetson AGX Thor T4000 | 64 GB / MAXN, 1530 MHz | Text | 1705 | 6519 Tok/s | 0.26 s | 34.1 Tok/s | 3.99 s |
+| Jetson AGX Thor T4000 | 64 GB / MAXN, 1530 MHz | Image | 911 | 3471 Tok/s | 0.26 s | 40.3 Tok/s | 3.41 s |
+| Jetson AGX Thor T4000 | 64 GB / MAXN, 1530 MHz | Video | 1263 | 4164 Tok/s | 0.30 s | 38.1 Tok/s | 3.64 s |
+| Jetson Thor T3000 | 32 GB / 1100 MHz | Text | 1705 | 5230 Tok/s | 0.33 s | 29.7 Tok/s | 4.61 s |
+| Jetson Thor T3000 | 32 GB / 1100 MHz | Image | 911 | 2710 Tok/s | 0.34 s | 36.3 Tok/s | 3.83 s |
+| Jetson Thor T3000 | 32 GB / 1100 MHz | Video | 1263 | 3388 Tok/s | 0.37 s | 33.7 Tok/s | 4.14 s |
+| Jetson Thor T2000 | 16 GB / 702 MHz, THOR_NANO | Text | 1705 | 2355 Tok/s | 0.72 s | 15.7 Tok/s | 8.80 s |
+| Jetson Thor T2000 | 16 GB / 702 MHz, THOR_NANO | Image | 911 | 1233 Tok/s | 0.74 s | 19.6 Tok/s | 7.21 s |
+| Jetson Thor T2000 | 16 GB / 702 MHz, THOR_NANO | Video | 1263 | 1543 Tok/s | 0.82 s | 18.0 Tok/s | 7.87 s |
+| Jetson AGX Orin | 64 GB | Text | 1705 | 3260 Tok/s | 0.52 s | 12.3 Tok/s | 10.83 s |
+| Jetson AGX Orin | 64 GB | Image | 911 | 1840 Tok/s | 0.50 s | 12.3 Tok/s | 10.81 s |
+| Jetson AGX Orin | 64 GB | Video | 1263 | 2103 Tok/s | 0.60 s | 12.2 Tok/s | 10.97 s |
+
+<sub>Notes:
+1. Source: vLLM inference benchmarking for `nvidia/Cosmos3-Edge`; metrics were collected with one GPU at client-side concurrency levels of 1, 64, 128, and 256.
+2. **Time To First Token (TTFT)** measures latency until the first output token is emitted. **Request Latency** is end-to-end time per request. For single-token outputs (Output 1), TTFT and request latency are identical.
+3. **Request Throughput** is completed requests per second. **Output Token Throughput** is generated tokens per second. For Output 1 workloads, the two throughput values match.
+4. Concurrency is the number of simultaneous client requests, not tensor-parallel GPU count.
+5. Embedded-platform measurements use Hugging Face Transformers in eager mode and should not be compared directly with the vLLM serving results.</sub>
 
 ## Cosmos3-Nano Reasoner
 


### PR DESCRIPTION
## Release: Cosmos3-Edge and Distillation support

Brings the public repo to parity with the private repo (nvidia-cosmos/cosmos-private) by importing all content from `cosmos-private/main` as a single snapshot. After merge, `origin/main` is byte-for-byte identical to `cosmos-private/main` — verified locally (0 file differences, identical tree hash).

### Highlights

**Cosmos3-Edge support**
- SFT recipes for the compact 2B Edge backbone across Generator (vision), Reasoner (videophy2), and Action (DROID policy)
- Edge inference benchmarks (`inference_benchmarks.md`) and updated Model Family table
- vLLM / vLLM-Omni cookbooks extended to Edge; Reasoner serving switched to Docker
- README specs and quickstart notes for Cosmos3-Edge

**Distillation support**
- Cosmos3 DMD2 distillation recipe for the audiovisual Generator (`distill/`): config builder, launch scripts, and i2v/t2i TOMLs

**Cookbook & docs**
- Renamed `*_with_vllm` cookbooks to `*_with_vllm_omni`
- Removed standalone vLLM cookbook notebooks (superseded by vLLM-Omni)
- Documented export + convert-to-diffusers across SFT recipes

### Scope
- 38 files changed (+2947 / -437)
- Squashes 37 private commits into one snapshot for a clean public history

🤖 Generated with [Claude Code](https://claude.com/claude-code)