### PR TITLE
docs: update Cosmos3-Edge 121-frame benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,11 +1139,11 @@ We are building examples that show Cosmos 3 Super/Nano/Edge capabilities end to 
 
 ### Inference Benchmarks
 
-Cosmos 3 latency and serving results live in [`inference_benchmarks.md`](inference_benchmarks.md). Generator sections report visual-generation and world-model latency in seconds across GPUs and integrated computing platforms, including image and video generation, forward and inverse dynamics, and policy generation. Reasoner sections report vLLM serving metrics under concurrent load, with additional eager Transformers measurements for embedded platforms. Empty cells mean a combination has not been measured yet, not that it is unsupported.
+Cosmos 3 latency and serving results live in [`inference_benchmarks.md`](inference_benchmarks.md). Generator sections report visual-generation latency in seconds across GPUs and integrated computing platforms, including text-to-image, text-to-video, and image-to-video. Cosmos3-Edge video benchmarks use 121 output frames at 480p unless noted otherwise. Reasoner sections report vLLM serving metrics under concurrent load, with additional eager Transformers measurements for embedded platforms. Empty cells mean a combination has not been measured yet, not that it is unsupported.
 
 | Benchmark | Surface | Model | What it covers |
 | --- | --- | --- | --- |
-| [Cosmos3-Edge generator](inference_benchmarks.md#cosmos3-edge-generator) | Generator | Cosmos3-Edge | Image-to-video, forward dynamics, inverse dynamics, and DROID policy latency across PyTorch and vLLM-Omni on data center, workstation, and embedded platforms |
+| [Cosmos3-Edge generator](inference_benchmarks.md#cosmos3-edge-generator) | Generator | Cosmos3-Edge | 121-frame image-to-video and text-to-video latency, plus text-to-image latency, across PyTorch and vLLM-Omni |
 | [Cosmos3-Nano generator](inference_benchmarks.md#cosmos3-nano-generator) | Generator | Cosmos3-Nano | Text-to-image, text-to-video, and image-to-video latency across PyTorch, vLLM-Omni, Diffusers, and NIM |
 | [Cosmos3-Super generator](inference_benchmarks.md#cosmos3-super-generator) | Generator | Cosmos3-Super | The same modalities and engines at the larger checkpoint scale |
 | [Cosmos3-Edge reasoner](inference_benchmarks.md#cosmos3-edge-reasoner) | Reasoner | Cosmos3-Edge | vLLM serving metrics on RTX PRO GPUs and eager Transformers prefill, decode, and end-to-end latency on embedded platforms |

--- a/inference_benchmarks.md
+++ b/inference_benchmarks.md
@@ -41,48 +41,51 @@ Generator results are published incrementally from internal benchmark runs. **Em
 
 ## Cosmos3-Edge Generator
 
-These tables report **Cosmos3-Edge** Generator latency in seconds for **image-to-video**, **forward dynamics**, **inverse dynamics**, and **DROID policy generation**. Measurements use one GPU or one integrated computing platform. Lower latency is better, and empty cells indicate that a run has not been completed.
+These tables report **Cosmos3-Edge** Generator latency in seconds for **image-to-video (i2v)**, **text-to-video (t2v)**, and **text-to-image (t2i)**. Measurements use one GPU or one integrated computing platform. Lower latency is better, and empty cells indicate that a run has not been completed.
 
-Unless otherwise noted, visual-generation benchmarks use **480p resolution**, and image-to-video benchmarks generate **189 frames**. vLLM-Omni values report end-to-end latency, while PyTorch values report average generation latency.
+Unless otherwise noted, visual-generation benchmarks use **480p resolution**. Video benchmarks generate **121 frames**; t2i is a single-image workload. vLLM-Omni values report end-to-end latency, while PyTorch values report average generation latency.
 
 ### vLLM-Omni
 
-| GPU or Platform | Image-to-Video | Forward Dynamics | Inverse Dynamics | Policy DROID |
-|---|---:|---:|---:|---:|
-| B200 SXM 192 GB |  | 2.44 | 3.98 | 0.99 |
-| H100 SXM 80 GB | 27.64 | 3.91 | 5.60 | 1.41 |
-| H100 NVL 96 GB | 35.60 | 4.73 | 6.39 | 1.37 |
-| H20 SXM 96 GB | 108.16 | 12.77 | 15.49 | 3.41 |
-| RTX PRO 6000 Blackwell Server Edition | 36.29 | 5.65 | 7.46 | 1.87 |
-| DGX Station | 12.17 | 4.33 | 6.34 | 8.11 |
-| DGX Spark | 165.96 | 26.43 | 30.86 | 7.66 |
-| Jetson AGX Thor T5000, 128 GB, MAXN | 137.50 | 6.05 | 7.19 | 6.32 |
-| Jetson T3000, 32 GB, 1100 MHz | 194.76 | 8.67 | 10.25 | 8.63 |
-| Jetson T2000, 16 GB, 702 MHz, THOR_NANO | 101.20 |  |  |  |
+| GPU or Platform | Image-to-Video | Text-to-Video | Text-to-Image |
+|---|---:|---:|---:|
+| B200 SXM 192 GB | 7.09 | 7.04 |  |
+| B300 | 8.74 | 8.68 |  |
+| H200 SXM 141 GB | 13.13 | 13.11 |  |
+| H200 NVL | 14.15 | 14.11 |  |
+| H100 SXM 80 GB | 13.33 | 13.30 |  |
+| H100 NVL 96 GB | 17.33 | 17.29 |  |
+| H20 SXM 96 GB | 53.94 | 53.98 |  |
+| RTX PRO 6000 Blackwell Server Edition |  |  |  |
+| DGX Station | 7.13 | 7.09 |  |
+| DGX Spark | 89.41 | 89.80 |  |
+| Jetson AGX Thor T5000, 128 GB, MAXN |  |  |  |
+| Jetson T3000, 32 GB, 1100 MHz |  |  |  |
+| Jetson T2000, 16 GB, 702 MHz, THOR_NANO |  |  |  |
 
 ### PyTorch
 
-| GPU or Platform | Image-to-Video | Forward Dynamics | Inverse Dynamics | Policy DROID |
-|---|---:|---:|---:|---:|
-| H100 SXM 80 GB | 23.92 | 3.69 | 3.56 | 1.25 |
-| H100 NVL 96 GB | 32.24 | 4.64 | 4.52 | 1.28 |
-| H20 SXM 96 GB | 97.51 | 12.78 | 12.64 | 2.92 |
-| RTX PRO 6000 Blackwell Server Edition | 38.98 | 5.26 | 5.66 | 1.32 |
-| DGX Station | 10.57 | 2.16 | 2.26 | 1.30 |
-| DGX Spark | 179.80 | 24.59 | 26.76 | 5.44 |
-| Jetson AGX Thor T5000, 128 GB, MAXN | 153.00 |  |  |  |
-| Jetson T3000, 32 GB, 1100 MHz | 227.80 |  |  |  |
+| GPU or Platform | Image-to-Video | Text-to-Video | Text-to-Image |
+|---|---:|---:|---:|
+| B200 SXM 192 GB | 7.45 | 7.83 | 1.96 |
+| B300 | 6.84 | 7.09 | 1.93 |
+| H200 SXM 141 GB | 12.31 | 12.81 | 2.52 |
+| H200 NVL | 14.07 | 14.49 | 2.32 |
+| H100 SXM 80 GB | 12.68 | 13.25 | 2.47 |
+| H100 NVL 96 GB | 16.42 | 17.12 | 2.47 |
+| H20 SXM 96 GB | 52.83 | 54.60 | 4.89 |
+| RTX PRO 6000 Blackwell Server Edition | 21.92 | 22.72 | 2.63 |
+| DGX Station | 6.31 | 6.76 | 3.32 |
+| DGX Spark | 103.36 | 108.78 | 8.87 |
+| Jetson AGX Thor T5000, 128 GB, MAXN |  |  |  |
+| Jetson T3000, 32 GB, 1100 MHz |  |  |  |
 
 <sub>Notes:
 1. All measurements use one GPU or one integrated computing platform.
 2. Values are average end-to-end or generation latency in seconds; lower is better.
 3. Unless otherwise specified, visual-generation measurements use **480p resolution**.
-4. Image-to-video measurements generate **189 output frames**.
-5. Jetson AGX Thor T5000 and Jetson T3000 visual-generation measurements use **832 × 480** resolution.
-6. Jetson T2000 visual-generation measurements use **448 × 256** resolution and therefore should not be compared directly with the 480p results. Its image-to-video values are warm-run measurements generating 189 frames.
-7. PyTorch values report average generation latency rather than diffusion-only latency.
-8. Datacenter and enterprise forward- and inverse-dynamics results use the autonomous-driving (`AV`) configuration.
-9. Jetson AGX Thor T5000 and Jetson T3000 forward-dynamics, inverse-dynamics, and policy measurements use the DROID configuration with action chunk `[16, 8]`.</sub>
+4. Video measurements (i2v and t2v) generate **121 output frames**. Text-to-image is not a video workload.
+5. PyTorch values report average generation latency rather than diffusion-only latency.</sub>
 
 ## Cosmos3-Nano Generator
 


### PR DESCRIPTION
## Summary

Updates Cosmos3-Edge Generator inference benchmarks using the 121-frame rerun results.

- Replaces legacy 189-frame visual-generation values with 121-frame measurements.
- Updates 480p Image-to-Video (i2v) and Text-to-Video (t2v) latency for PyTorch and vLLM-Omni.
- Adds available Text-to-Image (t2i) PyTorch latency values.
- Adds B300, H200 SXM, and H200 NVL coverage.
- Leaves cells blank where no corresponding rerun measurement was provided.
- Aligns the README benchmark summary with the updated modalities and 121-frame benchmark basis.

## Validation

- Confirmed all imported values are reported in seconds.
- Confirmed video benchmarks use 121 output frames.
- Ran `git diff --check`.