### PR TITLE
Pin the DROID policy server setup to the torch 2.13 CUDA 13 group

### DIFF
--- a/cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md
+++ b/cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md
@@ -24,6 +24,7 @@ Build the Docker image:
 
 ```bash
 docker build \
+  --build-arg INSTALL_APEX=0 \
   -t cosmos-framework:latest \
   .
 ```
@@ -48,15 +49,11 @@ docker run \
   bash -c '\
     uv sync \
       --all-extras \
-      --group=cu130-train \
+      --group=cu130-torch213-train \
       --group=policy-server && \
     exec bash; \
   '
 ```
-
-The `--group=cu130-train` line targets a CUDA 13 driver (the default). On CUDA
-12.x systems, replace it with `--group=cu128-train` (see the
-[Cosmos3 cookbooks environment setup](../../README.md) for details).
 
 Inside the container, start the policy server:
 


### PR DESCRIPTION
## Summary

- Switch the `uv sync` line in the Cosmos3-Policy-DROID server guide from `--group=cu130-train` to `--group=cu130-torch213-train`, which is the group the `policy-server` extras are built against.
- Pass `--build-arg INSTALL_APEX=0` to the `docker build` step so the image skips the apex build, which is not needed to serve a policy and is the slowest part of the build.
- Drop the CUDA 12.x fallback note, since `cu128-train` has no torch 2.13 counterpart and would not pair with `policy-server`.

## Validation

- Confirmed `cu130-torch213-train` and `policy-server` both exist as dependency groups in the `cosmos-framework` `pyproject.toml`, and that `cu130-torch213-train` is one of the mutually exclusive train groups.
- Confirmed the `cosmos-framework` Dockerfile declares `ARG INSTALL_APEX=1` and skips the apex build when it is set to `0`.