### PR TITLE
cookbook(action): repair the DROID forward-dynamics action prep

### DIFF
--- a/cookbooks/cosmos3/generator/action/run_fd_with_cosmos_framework.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_fd_with_cosmos_framework.ipynb
@@ -588,7 +588,8 @@
     "                \"seed\": 0,\n",
     "                \"vision_path\": str(vision_path),\n",
     "            }\n",
-    "        )\n"
+    "        )\n",
+    "    return records"
    ]
   },
   {
@@ -1086,6 +1087,7 @@
     "    root=droid_dataset_root,\n",
     "    chunk_length=chunk_length,\n",
     "    action_normalization=\"quantile_rot\",\n",
+    "    apply_forward_clamp=True,\n",
     ")\n",
     "droid_records = create_record_from_dataset(droid_dataset, num_chunks, chunk_length)\n",
     "\n",
@@ -1095,7 +1097,8 @@
     "droid_fd_output_dir = COSMOS3_OUTPUT_ROOT / f\"action_forward_dynamics_{domain_name}_custom\"\n",
     "\n",
     "print(\"Loaded DROID samples from:\", droid_dataset_root)\n",
-    "print(\"Wrote droid autoregressive plan:\", droid_fd_input_path)\n"
+    "print(\"Wrote droid autoregressive plan:\", droid_fd_input_path)\n",
+    "print(droid_fd_input_path.read_text())"
    ]
   },
   {

--- a/cookbooks/cosmos3/generator/action/run_fd_with_diffusers.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_fd_with_diffusers.ipynb
@@ -1064,6 +1064,7 @@
     "    chunk_length=droid_chunk_length,\n",
     "    use_success_only=True,\n",
     "    action_normalization=\"quantile_rot\",\n",
+    "    apply_forward_clamp=True,\n",
     ")\n",
     "\n",
     "droid_chunks = []\n",

--- a/cookbooks/cosmos3/generator/action/run_fd_with_sglang.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_fd_with_sglang.ipynb
@@ -561,6 +561,7 @@
     "    root=robotics_dataset_root,\n",
     "    chunk_length=robotics_chunk_length,\n",
     "    action_normalization=\"quantile_rot\",\n",
+    "    apply_forward_clamp=True,\n",
     ")\n",
     "robotics_chunk_starts = [chunk_idx * robotics_chunk_length for chunk_idx in range(robotics_num_chunks)]\n",
     "assert robotics_chunk_starts[-1] < len(robotics_dataset)\n",

--- a/cookbooks/cosmos3/generator/action/run_fd_with_vllm_omni.ipynb
+++ b/cookbooks/cosmos3/generator/action/run_fd_with_vllm_omni.ipynb
@@ -577,6 +577,7 @@
     "robotics_dataset = DROIDMergedLeRobotDataset(\n",
     "    root=robotics_dataset_root,\n",
     "    action_normalization=\"quantile_rot\",\n",
+    "    apply_forward_clamp=True,\n",
     ")\n",
     "robotics_num_chunks = 5\n",
     "robotics_chunk_length = 16\n",


### PR DESCRIPTION
> **Blocked on NVIDIA/cosmos-framework#190.** Passing `apply_forward_clamp` before that parameter exists raises `TypeError`.

Two fixes to the four DROID forward-dynamics notebooks, both regressions from #317. `4 files changed, 8 insertions(+), 2 deletions(-)`.

## 1. Restore two lines dropped from `run_fd_with_cosmos_framework.ipynb`

#317 removed the last source line of each of the two cells it edited:

- `return records` — end of `create_record_from_dataset`
- `print(droid_fd_input_path.read_text())` — end of the DROID plan cell

Without the return, `create_record_from_dataset` yields `None` and both call sites fail:

```python
droid_records = create_record_from_dataset(droid_dataset, num_chunks, chunk_length)
droid_fd_input_path.write_text("".join(json.dumps(r) + "\n" for r in droid_records))
# TypeError: 'NoneType' object is not iterable
```

The **UMI** cell shares the same helper and breaks identically, though it has nothing to do with DROID action normalization. This notebook cannot currently be run end to end on `main`.

### Why only this notebook

The two lost lines are exactly the two whose `source` entry had no trailing newline. The cells edited in the other three notebooks all ended with one and came through intact:

| notebook | cell | last line before | dropped |
|---|---|---|---|
| cosmos_framework | 12 | `    return records` | **yes** |
| cosmos_framework | 32 | `print(droid_fd_input_path.read_text())` | **yes** |
| diffusers | 41 | `display(droid_first_frame)\n` | no |
| sglang | 15 | `print(robotics_fd_input_path.read_text())\n` | no |
| vllm_omni | 16 | `print(robotics_fd_input_path.read_text())\n` | no |

That is the signature of a `"".join(source).split("\n")[:-1]` round-trip: when the last entry ends in `\n` the trailing element is an empty string and slicing it off is harmless, otherwise it discards a real line. Worth knowing for whatever tooling edits these notebooks — it will do this again.

## 2. Ask the dataset to forward-clamp DROID actions

#314 built the normalizer by hand with `apply_forward_clamp=True`. #317 moved that onto the dataset, which builds it with the `False` default, so the notebooks stopped clamping into `[-1, 1]`. Passing the flag matches #314 again.

Measured on the bundled `droid_lerobot_example` — 706 stride-1 windows, 112,960 action scalars — clamped vs unclamped:

| | |
|---|---|
| scalars outside q01/q99 | 1,253 (1.1092%) |
| windows with ≥1 outlier | 155/706 (21.95%) |
| non-overlapping chunks hit | 11/45 (24.4%) |
| max \|unclamped\| | 1.7818 |
| max \|difference\| | 0.78180099 |

87% of those outliers are on the rot6d channels; the gripper never exceeds the range, its q01/q99 being exactly `[0, 1]`.

The first five chunks — the ones these notebooks use — contain **no** outliers at all. That is why a five-chunk comparison comes out bit-identical either way and cannot distinguish clamped from unclamped, which is what the existing verification measured.

## Verification

With the flag, the dataset reproduces #314 exactly on the bundled fixture: all **706/706** windows identical, including the **155** where the clamp engages, `max|diff| = 0.0000000000`. The two normalizers also agree in `offset`, `scale`, `forward_clamp`, `forward_clamp_mask` and type, so they are the same function on every input.

Structural checks on the notebooks: cell counts unchanged, every cell's last source line unchanged, all code cells parse, `create_record_from_dataset` returns `records` again.

All four notebook dataset paths were then constructed with their own arguments and confirmed to build a clamping normalizer:

| notebook | construction | `forward_clamp` |
|---|---|---|
| cosmos_framework | `DROIDMergedLeRobotDataset(root, chunk_length, ...)` | `(-1.0, 1.0)` |
| sglang | `DROIDMergedLeRobotDataset(root, chunk_length, ...)` | `(-1.0, 1.0)` |
| vllm_omni | `DROIDMergedLeRobotDataset(root, ...)` — no `chunk_length` | `(-1.0, 1.0)` |
| diffusers | `DROIDLeRobotDataset(root, chunk_length, use_success_only=True, ...)` | `(-1.0, 1.0)` |

`run_fd_with_diffusers.ipynb` is the one that differs: it uses `DROIDLeRobotDataset` rather than the merged subclass, and that class picks its feature layout from the directory basename, so it rejects `droid_lerobot_example` outright with `ValueError: Unknown version`. It was exercised by reproducing the release layout the notebook itself builds — a `droid_plus_lerobot_640x360_20260412/success` symlink to the bundled sample — which it accepts (706 windows, same episode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
