### PR TITLE
cookbook(action): document the DROID policy server guidance interval

### DIFF
--- a/cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md
+++ b/cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md
@@ -70,8 +70,13 @@ Inside the container, start the policy server:
    python -m cosmos_framework.scripts.action_policy_server_robolab \
      --checkpoint-path nvidia/Cosmos3-Edge-Policy-DROID \
      --port 8000 \
-     --format-prompt-as-json True
+     --format-prompt-as-json True \
+     --guidance-interval 960 1001
    ```
+
+   The guidance interval applies classifier-free guidance only to denoising
+   timesteps in the inclusive range `[960, 1001]`. Omit
+   `--guidance-interval` to apply guidance at every denoising step.
 
 ## Simulation Client
 


### PR DESCRIPTION
Mirrors [NVIDIA/cosmos-framework#202](https://github.com/NVIDIA/cosmos-framework/pull/202) in the cookbook copy of the DROID policy server guide, as requested in the profiling thread.

Profiling the two stacks side by side showed the Cosmos framework path running 8 denoiser forwards per generation (`[2, 2, 2, 2]` across the four denoising steps) where the internal stack runs 5 (`[2, 1, 1, 1]`) — guidance was being applied at every step instead of only the first. cosmos-framework#202 adds a `--guidance-interval` flag to `action_policy_server_robolab` to close that gap; this PR documents it in `cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md`, which is the cookbook counterpart of `docs/action_policy_droid_server.md` upstream.

Doc-only change: adds `--guidance-interval 960 1001` to the Cosmos3-Edge-Policy-DROID server invocation plus a short explanation. The Nano invocation is unchanged, matching upstream.

**Blocked on cosmos-framework#202** — kept as a draft until that merges, since `--guidance-interval` does not exist on cosmos-framework `main` yet and the documented command would fail for anyone following it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)