### PR TITLE
cookbooks/cosmos3 audiovisual + benchmarks: remove Cosmos3-Edge t2i/t2v examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1181,7 +1181,7 @@ Cosmos 3 latency and serving results live in [`inference_benchmarks.md`](inferen
 
 | Benchmark | Surface | Model | What it covers |
 | --- | --- | --- | --- |
-| [Cosmos3-Edge generator](inference_benchmarks.md#cosmos3-edge-generator) | Generator | Cosmos3-Edge | 121-frame image-to-video and text-to-video latency, plus text-to-image latency, across PyTorch and vLLM-Omni |
+| [Cosmos3-Edge generator](inference_benchmarks.md#cosmos3-edge-generator) | Generator | Cosmos3-Edge | 121-frame image-to-video latency across PyTorch and vLLM-Omni |
 | [Cosmos3-Nano generator](inference_benchmarks.md#cosmos3-nano-generator) | Generator | Cosmos3-Nano | Text-to-image, text-to-video, and image-to-video latency across PyTorch, vLLM-Omni, Diffusers, and NIM |
 | [Cosmos3-Super generator](inference_benchmarks.md#cosmos3-super-generator) | Generator | Cosmos3-Super | The same modalities and engines at the larger checkpoint scale |
 | [Cosmos3-Edge reasoner](inference_benchmarks.md#cosmos3-edge-reasoner) | Reasoner | Cosmos3-Edge | vLLM serving metrics on RTX PRO GPUs and eager Transformers prefill, decode, and end-to-end latency on embedded platforms |

--- a/cookbooks/cosmos3/generator/audiovisual/README.md
+++ b/cookbooks/cosmos3/generator/audiovisual/README.md
@@ -155,8 +155,7 @@ single-GPU, no-audio settings: `height=480`, `width=832`, `num_frames=121`,
 the Diffusers backend: it provisions a dedicated venv, then walks through
 text-to-image, text-to-video, image-to-video, and video-to-video generation (with
 and without audio) using `Cosmos3OmniPipeline`, including a dedicated Cosmos3-Edge
-section with 480p text-to-image, text-to-video, and image-to-video examples and
-previews.
+section with a 480p image-to-video example and preview.
 
 ## Run with vLLM-Omni
 

--- a/cookbooks/cosmos3/generator/audiovisual/run_with_diffusers.ipynb
+++ b/cookbooks/cosmos3/generator/audiovisual/run_with_diffusers.ipynb
@@ -383,43 +383,11 @@
     "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
     "        \"enable_sound\": False,\n",
     "    },\n",
-    "    \"t2i_edge\": {\n",
-    "        \"model\": \"Cosmos3-Edge\",\n",
-    "        \"mode\": \"text2image\",\n",
-    "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
-    "        \"enable_sound\": False,\n",
-    "        \"sampling\": {\n",
-    "            \"num_steps\": 50,\n",
-    "            \"guidance\": 5.0,\n",
-    "            \"shift\": 3.0,\n",
-    "            \"fps\": 24,\n",
-    "            \"num_frames\": 1,\n",
-    "            \"resolution\": \"480\",\n",
-    "            \"aspect_ratio\": \"16,9\",\n",
-    "            \"seed\": 0,\n",
-    "        },\n",
-    "    },\n",
     "    \"t2v_nano_noaudio\": {\n",
     "        \"model\": \"Cosmos3-Nano\",\n",
     "        \"mode\": \"text2video\",\n",
     "        \"prompt\": \"assets/prompts/text2video/robot_kitchen.json\",\n",
     "        \"enable_sound\": False,\n",
-    "    },\n",
-    "    \"t2v_edge_noaudio\": {\n",
-    "        \"model\": \"Cosmos3-Edge\",\n",
-    "        \"mode\": \"text2video\",\n",
-    "        \"prompt\": \"assets/prompts/text2video/robot_kitchen.json\",\n",
-    "        \"enable_sound\": False,\n",
-    "        \"sampling\": {\n",
-    "            \"num_steps\": 50,\n",
-    "            \"guidance\": 5.0,\n",
-    "            \"shift\": 3.0,\n",
-    "            \"fps\": 24,\n",
-    "            \"num_frames\": 121,\n",
-    "            \"resolution\": \"480\",\n",
-    "            \"aspect_ratio\": \"16,9\",\n",
-    "            \"seed\": 0,\n",
-    "        },\n",
     "    },\n",
     "    \"t2vs\": {\n",
     "        \"model\": \"Cosmos3-Nano\",\n",
@@ -889,10 +857,7 @@
     "    for src in images:\n",
     "        print(f\"source: {src} ({src.stat().st_size // 1024} KB)\")\n",
     "        display(Image(filename=str(src), width=720))\n"
-   ],
-   "execution_count": null,
-   "outputs": [],
-   "id": "77e18231"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1254,7 +1219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f58eb8b",
+   "id": "v2v-nano-noaudio-md",
    "metadata": {},
    "source": [
     "## Nano: Video to Video Without Audio\n",
@@ -1262,8 +1227,7 @@
     "Nano video-to-video generation from a reference clip, with audio disabled. The first two latent frames of the reference clip are kept as clean conditioning and the rest are denoised.\n",
     "\n",
     "### Create Payload\n"
-   ],
-   "id": "v2v-nano-noaudio-md"
+   ]
   },
   {
    "cell_type": "code",
@@ -1588,122 +1552,6 @@
     "# Cosmos3-Edge Examples\n",
     "\n",
     "Cosmos3-Edge runs on a single GPU and has no audio tokenizer, so all Edge video examples keep audio disabled. The Edge checkpoint is trained for 480p generation; these examples use 832x480, 121 frames, 50 denoising steps, guidance scale 5.0, and flow shift 3.0.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c5e29c2a",
-   "metadata": {},
-   "source": [
-    "## Edge: Text to Image\n",
-    "\n",
-    "Generate a single 832x480 image from the structured JSON prompt.\n",
-    "\n",
-    "### Create Payload\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "edd2c2ed",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t2i_edge_payload, t2i_edge_output, t2i_edge_model = create_payload(\"t2i_edge\", backend=\"diffusers\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "444115f2",
-   "metadata": {},
-   "source": [
-    "### Run\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65857776",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_diffusers_payload(t2i_edge_payload, t2i_edge_output, model=\"Cosmos3-Edge\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9c1d7b62",
-   "metadata": {},
-   "source": [
-    "### View Results\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d4cd4817",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "view_run(t2i_edge_output)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2fb4e265",
-   "metadata": {},
-   "source": [
-    "## Edge: Text to Video Without Audio\n",
-    "\n",
-    "Generate a 121-frame 832x480 video from the structured JSON prompt.\n",
-    "\n",
-    "### Create Payload\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c133f313",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t2v_edge_noaudio_payload, t2v_edge_noaudio_output, t2v_edge_noaudio_model = create_payload(\"t2v_edge_noaudio\", backend=\"diffusers\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "490c2c93",
-   "metadata": {},
-   "source": [
-    "### Run\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "557831a9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_diffusers_payload(t2v_edge_noaudio_payload, t2v_edge_noaudio_output, model=\"Cosmos3-Edge\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6fdd64ed",
-   "metadata": {},
-   "source": [
-    "### View Results\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "44f6f2e8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "view_run(t2v_edge_noaudio_output)\n"
    ]
   },
   {

--- a/cookbooks/cosmos3/generator/audiovisual/run_with_diffusers.ipynb
+++ b/cookbooks/cosmos3/generator/audiovisual/run_with_diffusers.ipynb
@@ -1548,11 +1548,7 @@
    "cell_type": "markdown",
    "id": "482d68de",
    "metadata": {},
-   "source": [
-    "# Cosmos3-Edge Examples\n",
-    "\n",
-    "Cosmos3-Edge runs on a single GPU and has no audio tokenizer, so all Edge video examples keep audio disabled. The Edge checkpoint is trained for 480p generation; these examples use 832x480, 121 frames, 50 denoising steps, guidance scale 5.0, and flow shift 3.0.\n"
-   ]
+   "source": "# Cosmos3-Edge Example\n\nCosmos3-Edge runs on a single GPU and has no audio tokenizer, so the Edge video example keeps audio disabled. The Edge checkpoint is trained for 480p generation; this example uses 832x480, 121 frames, 20 denoising steps, guidance scale 6.0, and flow shift 12.0.\n"
   },
   {
    "cell_type": "markdown",

--- a/cookbooks/cosmos3/generator/audiovisual/run_with_vllm_omni.ipynb
+++ b/cookbooks/cosmos3/generator/audiovisual/run_with_vllm_omni.ipynb
@@ -1168,11 +1168,7 @@
    "cell_type": "markdown",
    "id": "edge-heading",
    "metadata": {},
-   "source": [
-    "# Cosmos3-Edge Examples\n",
-    "\n",
-    "Text-to-image, text-to-video, and image-to-video use cases for the `Cosmos3-Edge` model. Both video examples have audio disabled. This section is self-contained; you can run it without the model-specific sections above."
-   ]
+   "source": "# Cosmos3-Edge Example\n\nImage-to-video use case for the `Cosmos3-Edge` model. The video example has audio disabled. This section is self-contained; you can run it without the model-specific sections above."
   },
   {
    "cell_type": "markdown",

--- a/cookbooks/cosmos3/generator/audiovisual/run_with_vllm_omni.ipynb
+++ b/cookbooks/cosmos3/generator/audiovisual/run_with_vllm_omni.ipynb
@@ -284,20 +284,8 @@
     "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
     "        \"enable_sound\": False,\n",
     "    },\n",
-    "    \"t2i_edge\": {\n",
-    "        \"model\": \"Cosmos3-Edge\",\n",
-    "        \"mode\": \"text2image\",\n",
-    "        \"prompt\": \"assets/prompts/text2image/robot_draping.json\",\n",
-    "        \"enable_sound\": False,\n",
-    "    },\n",
     "    \"t2v_nano_noaudio\": {\n",
     "        \"model\": \"Cosmos3-Nano\",\n",
-    "        \"mode\": \"text2video\",\n",
-    "        \"prompt\": \"assets/prompts/text2video/robot_kitchen.json\",\n",
-    "        \"enable_sound\": False,\n",
-    "    },\n",
-    "    \"t2v_edge_noaudio\": {\n",
-    "        \"model\": \"Cosmos3-Edge\",\n",
     "        \"mode\": \"text2video\",\n",
     "        \"prompt\": \"assets/prompts/text2video/robot_kitchen.json\",\n",
     "        \"enable_sound\": False,\n",
@@ -1184,122 +1172,6 @@
     "# Cosmos3-Edge Examples\n",
     "\n",
     "Text-to-image, text-to-video, and image-to-video use cases for the `Cosmos3-Edge` model. Both video examples have audio disabled. This section is self-contained; you can run it without the model-specific sections above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edge-t2i-heading",
-   "metadata": {},
-   "source": [
-    "## Edge: Text to Image\n",
-    "\n",
-    "Edge text-to-image generation using a structured JSON prompt.\n",
-    "\n",
-    "### Create Payload"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "edge-t2i-payload",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t2i_edge_payload, t2i_edge_output, t2i_edge_model = create_payload(\"t2i_edge\", backend=\"vllm\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edge-t2i-run-heading",
-   "metadata": {},
-   "source": [
-    "### Run\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "edge-t2i-run",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_vllm_payload(t2i_edge_payload, t2i_edge_output, model=\"Cosmos3-Edge\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edge-t2i-view-heading",
-   "metadata": {},
-   "source": [
-    "### View Results\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "edge-t2i-view",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "view_run(t2i_edge_output)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edge-t2v-heading",
-   "metadata": {},
-   "source": [
-    "## Edge: Text to Video Without Audio\n",
-    "\n",
-    "Edge text-to-video generation with audio disabled.\n",
-    "\n",
-    "### Create Payload"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "edge-t2v-payload",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t2v_edge_noaudio_payload, t2v_edge_noaudio_output, t2v_edge_noaudio_model = create_payload(\"t2v_edge_noaudio\", backend=\"vllm\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edge-t2v-run-heading",
-   "metadata": {},
-   "source": [
-    "### Run\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "edge-t2v-run",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run_vllm_payload(t2v_edge_noaudio_payload, t2v_edge_noaudio_output, model=\"Cosmos3-Edge\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "edge-t2v-view-heading",
-   "metadata": {},
-   "source": [
-    "### View Results\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "edge-t2v-view",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "view_run(t2v_edge_noaudio_output)"
    ]
   },
   {

--- a/inference_benchmarks.md
+++ b/inference_benchmarks.md
@@ -41,50 +41,50 @@ Generator results are published incrementally from internal benchmark runs. **Em
 
 ## Cosmos3-Edge Generator
 
-These tables report **Cosmos3-Edge** Generator latency in seconds for **image-to-video (i2v)**, **text-to-video (t2v)**, and **text-to-image (t2i)**. Measurements use one GPU or one integrated computing platform. Lower latency is better, and empty cells indicate that a run has not been completed.
+These tables report **Cosmos3-Edge** Generator latency in seconds for **image-to-video (i2v)**. Measurements use one GPU or one integrated computing platform. Lower latency is better, and empty cells indicate that a run has not been completed.
 
-Unless otherwise noted, visual-generation benchmarks use **480p resolution**. Video benchmarks generate **121 frames**; t2i is a single-image workload. vLLM-Omni values report end-to-end latency, while PyTorch values report average generation latency.
+Unless otherwise noted, visual-generation benchmarks use **480p resolution**. Video benchmarks generate **121 frames**. vLLM-Omni values report end-to-end latency, while PyTorch values report average generation latency.
 
 ### vLLM-Omni
 
-| GPU or Platform | Image-to-Video | Text-to-Video | Text-to-Image |
-|---|---:|---:|---:|
-| B200 SXM 192 GB | 7.09 | 7.04 |  |
-| B300 | 8.74 | 8.68 |  |
-| H200 SXM 141 GB | 13.13 | 13.11 |  |
-| H200 NVL | 14.15 | 14.11 |  |
-| H100 SXM 80 GB | 13.33 | 13.30 |  |
-| H100 NVL 96 GB | 17.33 | 17.29 |  |
-| H20 SXM 96 GB | 53.94 | 53.98 |  |
-| RTX PRO 6000 Blackwell Server Edition |  |  |  |
-| DGX Station | 7.13 | 7.09 |  |
-| DGX Spark | 89.41 | 89.80 |  |
-| Jetson AGX Thor T5000, 128 GB, MAXN |  |  |  |
-| Jetson T3000, 32 GB, 1100 MHz |  |  |  |
-| Jetson T2000, 16 GB, 702 MHz, THOR_NANO |  |  |  |
+| GPU or Platform | Image-to-Video |
+|---|---:|
+| B200 SXM 192 GB | 7.09 |
+| B300 | 8.74 |
+| H200 SXM 141 GB | 13.13 |
+| H200 NVL | 14.15 |
+| H100 SXM 80 GB | 13.33 |
+| H100 NVL 96 GB | 17.33 |
+| H20 SXM 96 GB | 53.94 |
+| RTX PRO 6000 Blackwell Server Edition |  |
+| DGX Station | 7.13 |
+| DGX Spark | 89.41 |
+| Jetson AGX Thor T5000, 128 GB, MAXN |  |
+| Jetson T3000, 32 GB, 1100 MHz |  |
+| Jetson T2000, 16 GB, 702 MHz, THOR_NANO |  |
 
 ### PyTorch
 
-| GPU or Platform | Image-to-Video | Text-to-Video | Text-to-Image |
-|---|---:|---:|---:|
-| B200 SXM 192 GB | 7.45 | 7.83 | 1.96 |
-| B300 | 6.84 | 7.09 | 1.93 |
-| H200 SXM 141 GB | 12.31 | 12.81 | 2.52 |
-| H200 NVL | 14.07 | 14.49 | 2.32 |
-| H100 SXM 80 GB | 12.68 | 13.25 | 2.47 |
-| H100 NVL 96 GB | 16.42 | 17.12 | 2.47 |
-| H20 SXM 96 GB | 52.83 | 54.60 | 4.89 |
-| RTX PRO 6000 Blackwell Server Edition | 21.92 | 22.72 | 2.63 |
-| DGX Station | 6.31 | 6.76 | 3.32 |
-| DGX Spark | 103.36 | 108.78 | 8.87 |
-| Jetson AGX Thor T5000, 128 GB, MAXN |  |  |  |
-| Jetson T3000, 32 GB, 1100 MHz |  |  |  |
+| GPU or Platform | Image-to-Video |
+|---|---:|
+| B200 SXM 192 GB | 7.45 |
+| B300 | 6.84 |
+| H200 SXM 141 GB | 12.31 |
+| H200 NVL | 14.07 |
+| H100 SXM 80 GB | 12.68 |
+| H100 NVL 96 GB | 16.42 |
+| H20 SXM 96 GB | 52.83 |
+| RTX PRO 6000 Blackwell Server Edition | 21.92 |
+| DGX Station | 6.31 |
+| DGX Spark | 103.36 |
+| Jetson AGX Thor T5000, 128 GB, MAXN |  |
+| Jetson T3000, 32 GB, 1100 MHz |  |
 
 <sub>Notes:
 1. All measurements use one GPU or one integrated computing platform.
 2. Values are average end-to-end or generation latency in seconds; lower is better.
 3. Unless otherwise specified, visual-generation measurements use **480p resolution**.
-4. Video measurements (i2v and t2v) generate **121 output frames**. Text-to-image is not a video workload.
+4. Video measurements (i2v) generate **121 output frames**.
 5. PyTorch values report average generation latency rather than diffusion-only latency.</sub>
 
 ## Cosmos3-Nano Generator


### PR DESCRIPTION
Cosmos3-Edge is image-to-video focused (256p/480p). This removes the text-to-image and text-to-video Edge examples and benchmark columns so the Edge material reflects i2v only.

Changes:
- cookbooks/cosmos3/generator/audiovisual/run_with_diffusers.ipynb: remove the Edge text-to-image and text-to-video example cells (keep Edge i2v).
- cookbooks/cosmos3/generator/audiovisual/run_with_vllm_omni.ipynb: same removal (keep Edge i2v).
- inference_benchmarks.md: drop the Text-to-Video and Text-to-Image columns from the Cosmos3-Edge Generator latency tables (vLLM-Omni + PyTorch), and update the intro/notes to i2v only.

Not touched: run_with_cosmos_framework.ipynb (its Edge example is already i2v-only) and README.md.