### PR TITLE
feat: add OrcaRouter as a named VLMEvalKit API provider

### DIFF
--- a/evaluation/cosmos3/reasoner/vlmevalkit/docs/en/Quickstart.md
+++ b/evaluation/cosmos3/reasoner/vlmevalkit/docs/en/Quickstart.md
@@ -47,6 +47,8 @@ To infer with API models (GPT-4v, Gemini-Pro-V, etc.) or use LLM APIs as the **j
   LMDEPLOY_API_BASE=
   # MiniMax API
   MINIMAX_API_KEY=
+  # OrcaRouter API
+  ORCAROUTER_API_KEY=
   # You can also set a proxy for calling api models during the evaluation stage
   EVAL_PROXY=
   ```

--- a/evaluation/cosmos3/reasoner/vlmevalkit/vlmeval/api/__init__.py
+++ b/evaluation/cosmos3/reasoner/vlmevalkit/vlmeval/api/__init__.py
@@ -24,6 +24,7 @@ from .mug_u import MUGUAPI
 from .nemotron import Nemotron
 from .nv_gemini import NVGemini
 from .openai_sdk import OpenAISDKWrapper
+from .orcarouter import OrcaRouterAPI
 from .qwen_api import QwenAPI
 from .qwen_vl_api import Qwen2VLAPI, QwenVLAPI, QwenVLWrapper
 from .rbdashmm_chat3_5_api import RBdashMMChat3_5_38B_API, RBdashMMChat3_78B_API
@@ -44,6 +45,7 @@ __all__ = [
     'SenseChatVisionAPI', 'SenseChatVisionV2API', 'HunyuanVision', 'Qwen2VLAPI', 'BlueLMWrapper', 'BlueLM_API',
     'JTVLChatAPI', 'JTVLChatAPI_Mini', 'JTVLChatAPI_2B', 'bailingMMAPI', 'TaiyiAPI', 'TeleMMAPI',
     'SiliconFlowAPI', 'LMDeployAPI', 'ARM_thinker', 'OpenAISDKWrapper', 'LMDeployWrapper',
+    'OrcaRouterAPI',
     'TaichuVLAPI', 'TaichuVLRAPI', 'DoubaoVL', "MUGUAPI", 'KimiVLAPIWrapper', 'KimiVLAPI',
     'RBdashMMChat3_API', 'RBdashChat3_5_API', 'RBdashMMChat3_78B_API', 'RBdashMMChat3_5_38B_API',
     'VideoChatOnlineV2API', 'TeleMM2_API', 'TeleMM2Thinking_API', 'TogetherAPI', 'GCPVertexAPI',

--- a/evaluation/cosmos3/reasoner/vlmevalkit/vlmeval/api/orcarouter.py
+++ b/evaluation/cosmos3/reasoner/vlmevalkit/vlmeval/api/orcarouter.py
@@ -1,0 +1,139 @@
+"""
+OrcaRouter API support for vision-language models.
+OpenAI-compatible chat completions with image_url (base64 or URL).
+Set ORCAROUTER_API_KEY or pass key=...
+"""
+import json
+import os
+
+import numpy as np
+import requests
+
+from ..smp import encode_image_to_base64, get_logger
+from .base import BaseAPI
+
+logger = get_logger(__name__)
+
+ORCAROUTER_API_BASE = "https://api.orcarouter.ai/v1/chat/completions"
+
+
+class OrcaRouterAPI(BaseAPI):
+    """VLM API using OrcaRouter (OpenAI-compatible; supports vision)."""
+
+    is_api: bool = True
+
+    def __init__(
+        self,
+        model: str = "google/gemini-3.1-flash-lite",
+        key: str = None,
+        api_base: str = None,
+        retry: int = 10,
+        wait: int = 1,
+        system_prompt: str = None,
+        verbose: bool = True,
+        temperature: float = 0,
+        max_tokens: int = 2048,
+        timeout: int = 300,
+        img_size: int = -1,
+        **kwargs,
+    ):
+        self.model = model
+        self.key = key or os.environ.get("ORCAROUTER_API_KEY")
+        self.api_base = api_base or os.environ.get("ORCAROUTER_API_BASE", ORCAROUTER_API_BASE)
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.timeout = timeout
+        self.img_size = img_size
+
+        if not self.key:
+            raise ValueError(
+                "OrcaRouter API key is required. Set ORCAROUTER_API_KEY or pass key=..."
+            )
+
+        super().__init__(
+            retry=retry,
+            wait=wait,
+            system_prompt=system_prompt,
+            verbose=verbose,
+            **kwargs,
+        )
+
+        logger.info(f"OrcaRouterAPI: model={self.model}, api_base={self.api_base}")
+
+    def _prepare_content(self, inputs):
+        """Build OpenAI-style content list (text + image_url with base64)."""
+        assert all(isinstance(x, dict) for x in inputs)
+        has_images = np.sum([x["type"] == "image" for x in inputs])
+        if has_images:
+            content_list = []
+            for item in inputs:
+                if item["type"] == "text":
+                    content_list.append({"type": "text", "text": item["value"]})
+                elif item["type"] == "image":
+                    from PIL import Image
+
+                    img = Image.open(item["value"])
+                    b64 = encode_image_to_base64(img, target_size=self.img_size)
+                    content_list.append({
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+                    })
+            return content_list
+        text = "\n".join([x["value"] for x in inputs if x["type"] == "text"])
+        return [{"type": "text", "text": text or ""}]
+
+    def _prepare_messages(self, inputs):
+        if self.system_prompt:
+            out = [{"role": "system", "content": self.system_prompt}]
+        else:
+            out = []
+        if inputs and "role" in inputs[0]:
+            for item in inputs:
+                out.append({
+                    "role": item["role"],
+                    "content": self._prepare_content(item["content"]),
+                })
+        else:
+            out.append({"role": "user", "content": self._prepare_content(inputs)})
+        return out
+
+    def generate_inner(self, inputs, **kwargs):
+        temperature = kwargs.pop("temperature", self.temperature)
+        max_tokens = kwargs.pop("max_tokens", self.max_tokens)
+
+        messages = self._prepare_messages(inputs)
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+
+        try:
+            response = requests.post(
+                self.api_base,
+                headers={
+                    "Authorization": f"Bearer {self.key}",
+                    "Content-Type": "application/json",
+                },
+                data=json.dumps(payload),
+                timeout=self.timeout * 1.1,
+            )
+        except Exception as err:
+            if self.verbose:
+                logger.error(f"{type(err).__name__}: {err}")
+            return -1, self.fail_msg, str(err)
+
+        ret_code = response.status_code
+        ret_code = 0 if (200 <= ret_code < 300) else ret_code
+        answer = self.fail_msg
+
+        try:
+            data = response.json()
+            answer = data["choices"][0]["message"]["content"].strip()
+        except Exception as err:
+            if self.verbose:
+                logger.error(f"{type(err).__name__}: {err}")
+                logger.error(response.text)
+
+        return ret_code, answer, response

--- a/evaluation/cosmos3/reasoner/vlmevalkit/vlmeval/config.py
+++ b/evaluation/cosmos3/reasoner/vlmevalkit/vlmeval/config.py
@@ -523,6 +523,31 @@ api_models = {
         max_tokens=2048,
         retry=10,
     ),
+    # OrcaRouter (set ORCAROUTER_API_KEY)
+    "OrcaRouter_Gemini-3.1-Flash-Lite": partial(
+        api.OrcaRouterAPI,
+        model="google/gemini-3.1-flash-lite",
+        temperature=0,
+        retry=10,
+    ),
+    "OrcaRouter_Gemini-3.5-Flash": partial(
+        api.OrcaRouterAPI,
+        model="google/gemini-3.5-flash",
+        temperature=0,
+        retry=10,
+    ),
+    "OrcaRouter_Claude-Sonnet-5": partial(
+        api.OrcaRouterAPI,
+        model="anthropic/claude-sonnet-5",
+        temperature=0,
+        retry=10,
+    ),
+    "OrcaRouter_DeepSeek-V4-Flash-Vision": partial(
+        api.OrcaRouterAPI,
+        model="deepseek/deepseek-v4-flash-vision-exp",
+        temperature=0,
+        retry=10,
+    ),
     # MiniMax (set MINIMAX_API_KEY)
     "MiniMax-M2.7": partial(
         api.MiniMaxAPI,


### PR DESCRIPTION
## Motivation

VLMEvalKit evaluates large vision-language models against a large registry of named API providers — Together AI, SiliconFlow, MiniMax, and others each have a first-class wrapper in `vlmeval/api/` plus preset entries in `vlmeval/config.py`. When benchmarking with an external model gateway, users currently have no way to pick OrcaRouter without treating it as an anonymous custom `--base-url`. This PR adds **OrcaRouter** as a first-class provider in the same style as the existing Together AI integration, so Cosmos Reasoner benchmarks can run against OrcaRouter's model namespace directly.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`vlmeval/api/orcarouter.py`** — new `OrcaRouterAPI` wrapper, modeled directly on `vlmeval/api/together.py`: OpenAI-compatible chat completions with `image_url` (base64 or URL) support, `ORCAROUTER_API_KEY` env key resolution, retries, and a configurable `api_base` defaulting to `https://api.orcarouter.ai/v1/chat/completions`.
- **`vlmeval/api/__init__.py`** — import and export `OrcaRouterAPI`.
- **`vlmeval/config.py`** — four preset `api_models` entries: `OrcaRouter_Gemini-3.1-Flash-Lite`, `OrcaRouter_Gemini-3.5-Flash`, `OrcaRouter_Claude-Sonnet-5`, and `OrcaRouter_DeepSeek-V4-Flash-Vision`.
- **`docs/en/Quickstart.md`** — add `ORCAROUTER_API_KEY` to the documented `.env` API-key list.

## Verification

- `python -m py_compile` and `flake8 --max-line-length=99` pass on the new files (config.py is pre-commit-excluded).
- L3 live round-trips through the new `OrcaRouterAPI` class against the live `https://api.orcarouter.ai/v1` endpoint succeeded for all four preset models (`google/gemini-3.1-flash-lite`, `google/gemini-3.5-flash`, `anthropic/claude-sonnet-5`, `deepseek/deepseek-v4-flash-vision-exp`), each returning `ret_code=0` with a valid completion.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
