### PR TITLE
docs(action): clarify embodiment-specific action dimensions

### DIFF
--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -56,6 +56,17 @@ fingers.
 | UMI | End-effector pose (9D) + gripper grasp state (1D) | 10D | Meter | Normalization | 16 frames @ 20FPS |
 | Human hand pose | Ego pose (9D) + right wrist (9D) + right fingertips (15D) + left wrist (9D) + left fingertips (15D) | 57D | Meter | Wrist-frame alignment, normalization | 16 frames @ 15FPS |
 
+Action dimensions are tied to the selected embodiment. `domain_name` chooses a registered
+action domain, and Cosmos Framework validates forward-dynamics input width against that
+domain's canonical raw action dimension. Changing a 10D DROID vector to 12D or 18D, for
+example, is not supported by the released checkpoints simply by changing the input shape.
+A custom action layout requires a compatible registered embodiment/domain and model weights
+trained for that action representation. Some dataset-defined domains, such as hand pose and
+LIBERO, can resolve their width from dataset configuration for forward dynamics; this does
+not make arbitrary widths interchangeable within a trained domain. See the
+[Cosmos Framework action-domain registry](https://github.com/NVIDIA/cosmos-framework/blob/main/cosmos_framework/data/generator/action/utils/domain_utils.py)
+for the currently registered canonical widths.
+
 Action data samples across different embodiments can be inspected interactively in the [Cosmos3 Action Viewer](https://huggingface.co/spaces/nvidia/Cosmos3-Action-Viewer) Hugging Face Space.
 
 ## Run with Cosmos Framework


### PR DESCRIPTION
## Summary

- clarify that action-vector dimensions are tied to the selected registered embodiment/domain
- explain that changing a trained domain's input width is not a drop-in way to use arbitrary action dimensions
- point readers to the Cosmos Framework action-domain registry and note the dataset-defined forward-dynamics exceptions

## Why

Issue #220 asks whether Cosmos3 can accept arbitrary action-space dimensions such as 12D, 16D, or 18D. The current Cosmos Framework validates `domain_name` against the action-domain registry and validates forward-dynamics action width against the registered raw dimension for ordinary domains. The cookbook currently lists example dimensions but does not state this constraint explicitly.

## Validation

Documentation-only change. Cross-checked against the current Cosmos Framework action inference path and `EMBODIMENT_TO_RAW_ACTION_DIM` registry.

Closes #220