### PR TITLE
docs(transfer): clarify WSM single-view support

### DIFF
--- a/cookbooks/cosmos3/generator/transfer/README.md
+++ b/cookbooks/cosmos3/generator/transfer/README.md
@@ -43,6 +43,12 @@ for the negative caption.
 | World scenario (WSM) | `assets/wsm/` | `control_wsm.mp4` + `prompt.json` | 101 frames @ 10 FPS |
 | Multi-control | `assets/multi_control/` | `vision_path` + multiple hints (Framework example) | 121 frames @ 30 FPS |
 
+World-scenario-map transfer is supported by both Cosmos3-Nano and Cosmos3-Super in the
+current release. Transfer generation is single-view: a WSM control video conditions one
+RGB output view per generation. The `multi-control` examples combine multiple control
+modalities for the same output view; they do not perform synchronized multi-camera
+generation. Joint multi-view video generation is not supported by the current release.
+
 Transfer inference is selected automatically when any hint key is present in the
 Framework spec or in vLLM-Omni `extra_params`.
 The same spec files are used for both Nano and Super — model selection is controlled


### PR DESCRIPTION
## Summary

- clarify that world-scenario-map transfer is supported by Cosmos3-Nano and Cosmos3-Super
- document that the current transfer path generates a single RGB view per WSM control video
- distinguish multi-control transfer from synchronized multi-camera generation

## Why

Issue #209 asks whether the released Cosmos3 models support world-scenario-map transfer and whether the MADS seven-camera setup implies joint multi-view generation. A maintainer confirmed that WSM transfer is supported, while the current release supports single-view generation only.

The transfer README already documents WSM and multi-control inputs, but it does not state this single-view limitation explicitly. This small clarification puts the maintainer-confirmed behaviour next to the relevant controls and avoids ambiguity between multi-control and multi-view generation.

## Validation

Documentation-only change. Cross-checked against the existing WSM transfer example and the maintainer response in #209.

Closes #209