### PR TITLE
docs(distill) clarify published four-step checkpoint scope

### DIFF
--- a/cookbooks/cosmos3/generator/audiovisual/distill/README.md
+++ b/cookbooks/cosmos3/generator/audiovisual/distill/README.md
@@ -6,6 +6,13 @@ SPDX-License-Identifier: OpenMDW-1.1 -->
 This cookbook demonstrates short DMD2 distillation smoke runs for the released
 Cosmos3-Super Text2Image and Image2Video models with Cosmos Framework.
 
+The published four-step checkpoints are task-specific distilled students for
+Cosmos3-Super Text2Image and Image2Video. They are separate from the multi-task
+`Cosmos3-Nano` and `Cosmos3-Super` base checkpoints; this cookbook does not
+provide a four-step distilled base multi-task checkpoint. Fixed-step sampling
+support should therefore not be interpreted as meaning every Cosmos3 checkpoint
+is distilled.
+
 > This is a functional training recipe, not a production reproduction recipe.
 > It uses a small public dataset and six optimizer iterations to validate model
 > loading, loss and gradient computation, checkpoint resume, student-only


### PR DESCRIPTION
## Summary

- clarify that the published four-step checkpoints are task-specific T2I and I2V students
- distinguish those checkpoints from the multi-task Cosmos3-Nano and Cosmos3-Super base models
- clarify that fixed-step sampling support does not imply every Cosmos3 checkpoint is distilled

## Why

Issue #282 asked whether the presence of fixed-step sampling meant a distilled Cosmos3 variant was available. The project has since released Cosmos3-Super-Text2Image-4Step and Cosmos3-Super-Image2Video-4Step. A maintainer clarified that these are task-specific distilled models, while base multi-task Nano/Super distillation is separate work.

The distillation cookbook already lists the released students, but it does not explicitly state that scope. This small documentation change makes the distinction clear next to the distillation recipes.

## Validation

Documentation-only change. Cross-checked against the published four-step model entries, the distillation cookbook, and the maintainer clarification in #282.

Closes #282