### PR TITLE
docs(reasoner): clarify raw vLLM video sampling

### DIFF
--- a/cookbooks/cosmos3/reasoner/README.md
+++ b/cookbooks/cosmos3/reasoner/README.md
@@ -126,6 +126,33 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
+For video requests, frame-sampling controls are multimodal processor options. With
+the OpenAI client, pass them through `extra_body`:
+
+```python
+response = client.chat.completions.create(
+    model=client.models.list().data[0].id,
+    messages=messages,
+    extra_body={"mm_processor_kwargs": {"fps": 4, "do_sample_frames": True}},
+)
+```
+
+If you call `/v1/chat/completions` directly with `requests`, send the equivalent
+`mm_processor_kwargs` object in the JSON body. Do not send `fps` or
+`do_sample_frames` as standalone top-level chat-completion fields:
+
+```python
+payload = {
+    "model": "Cosmos3-Super",
+    "messages": messages,
+    "mm_processor_kwargs": {"fps": 4, "do_sample_frames": True},
+}
+```
+
+This is especially important for motion-dependent video tasks such as physical
+plausibility analysis, where the sampled frames determine which temporal events
+are visible to the Reasoner.
+
 ### Notebook walkthrough
 
 [`run_with_vllm.ipynb`](./run_with_vllm.ipynb) uses the **Cosmos3-Super** launch


### PR DESCRIPTION
## Summary

- document the correct vLLM frame-sampling request shape for video inputs
- show both the OpenAI client `extra_body` form and equivalent raw `/v1/chat/completions` JSON
- clarify that `fps` and `do_sample_frames` belong inside `mm_processor_kwargs`, not as standalone top-level chat-completion fields

## Why

Issue #190 reports weak physical-plausibility classification while sending `fps` and `do_sample_frames` as top-level fields in a raw `requests` payload. The current Reasoner prompt guide documents video sampling through `extra_body={"mm_processor_kwargs": ...}` for the OpenAI client, but the vLLM quickstart does not show the equivalent raw JSON shape.

That distinction matters for motion-dependent tasks such as physical plausibility analysis because frame sampling determines which temporal events are presented to the Reasoner. This change makes the raw HTTP configuration explicit next to the vLLM quickstart.

## Validation

Documentation-only change. Cross-checked against the current Reasoner prompt guide's `mm_processor_kwargs` sampling configuration and the request shown in #190.

Addresses #190