### PR TITLE
docs(action) clarify AgiBotWorld URDF scope

### DIFF
--- a/cookbooks/cosmos3/generator/action/README.md
+++ b/cookbooks/cosmos3/generator/action/README.md
@@ -58,6 +58,20 @@ fingers.
 
 Action data samples across different embodiments can be inspected interactively in the [Cosmos3 Action Viewer](https://huggingface.co/spaces/nvidia/Cosmos3-Action-Viewer) Hugging Face Space.
 
+### AgiBotWorld robot description
+
+The public Cosmos Framework AgiBotWorld forward-kinematics path currently uses the
+committed [`G1_omnipicker_calibrated.urdf`](https://github.com/NVIDIA/cosmos-framework/blob/main/cosmos_framework/data/generator/action/robot_assets/G1_omnipicker_calibrated.urdf)
+as its calibrated kinematics reference. The URDF contains `package://` references to
+visual meshes, but those mesh files are not bundled in the framework's `robot_assets`
+directory. They are not required by the action FK path: the loader removes `<visual>`
+and `<collision>` elements before constructing its MuJoCo kinematics model.
+
+Accordingly, the committed file should be treated as the kinematics reference for the
+registered omnipicker-based AgiBotWorld action path, not as a complete renderable robot
+asset package or a generic description for every AgiBotWorld gripper variant. The public
+framework does not currently include a separate CTEK URDF or the referenced mesh package.
+
 ## Run with Cosmos Framework
 
 ### Quickstart


### PR DESCRIPTION
## Summary

- clarify that the public AgiBotWorld FK path uses `G1_omnipicker_calibrated.urdf` as a kinematics reference
- document that the URDF's referenced visual mesh package is not bundled in `robot_assets`
- explain that the FK loader strips visual and collision elements before constructing its MuJoCo kinematics model
- clarify that the committed file is not a complete renderable description for every AgiBotWorld gripper variant

## Why

Issue #305 asks why the AgiBotWorld Beta data appears to use a CTEK gripper while the available URDF is an omnipicker description, and asks for the complete mesh-backed URDF.

The current public Cosmos Framework hard-codes `G1_omnipicker_calibrated.urdf` for the AgiBotWorld FK path. The URDF contains `package://genie_robot_description/meshes/...` references, but the corresponding mesh package is not included in the public `robot_assets` directory. This does not block the current action FK path because the loader explicitly removes `<visual>` and `<collision>` elements before loading the model into MuJoCo.

This documentation change makes the scope of the published robot description explicit and avoids implying that it is a complete renderable CTEK/omnipicker asset package.

## Validation

Documentation-only change. Cross-checked against `agibot_spec.py`, `agibot_fk.py`, the committed `G1_omnipicker_calibrated.urdf`, and the current `robot_assets` directory in NVIDIA/cosmos-framework.

Addresses #305